### PR TITLE
add UDF for converting a date represented as YYYYMMDD to a BigQuery D…

### DIFF
--- a/udfs/community/README.md
+++ b/udfs/community/README.md
@@ -133,3 +133,13 @@ SELECT bqutil.fn.url_param(
 
 "chrome"
 ```
+
+
+### [y4md_to_date(y4md STRING)](y4md_to_date.sql)
+Convert a STRING formatted as a YYYYMMDD to a DATE
+
+```sql
+SELECT bqutil.fn.y4md_to_date('20201220')
+
+"2020-12-20"
+```

--- a/udfs/community/y4md_to_date.sql
+++ b/udfs/community/y4md_to_date.sql
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+CREATE OR REPLACE FUNCTION
+  fn.Y4MD_TO_DATE(y4md STRING)
+  RETURNS DATE AS ( CAST(CONCAT(SUBSTR(y4md, 0, 4), '-', SUBSTR(y4md, 5, 2), '-', SUBSTR(y4md, 7, 2)) AS DATE) );
+  

--- a/udfs/community/y4md_to_date.sql
+++ b/udfs/community/y4md_to_date.sql
@@ -15,6 +15,6 @@
  */
 
 CREATE OR REPLACE FUNCTION
-  fn.Y4MD_TO_DATE(y4md STRING)
+  fn.y4md_to_date(y4md STRING)
   RETURNS DATE AS ( CAST(CONCAT(SUBSTR(y4md, 0, 4), '-', SUBSTR(y4md, 5, 2), '-', SUBSTR(y4md, 7, 2)) AS DATE) );
   


### PR DESCRIPTION
…ATE type

UDF that takes a STRING date representation formatted as `+%Y%m%d` or `YYYYMMDD` and returns the value as a BigQuery DATE type.

```
bq query --quiet --headless --use_legacy_sql=false "SELECT fn.Y4MD_TO_DATE('20191231') AS converted_date"
+----------------+
| converted_date |
+----------------+
|     2019-12-31 |
+----------------+
```