### PR TITLE
Update to newer cloud sdk image

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -17,7 +17,7 @@ steps:
 ###########################################################
 # Step 1: Deploy
 ###########################################################
-- name: gcr.io/cloud-builders/gcloud
+- name: gcr.io/google.com/cloudsdktool/cloud-sdk
   entrypoint: 'bash'
   args: ['release/build.sh', '$BRANCH_NAME', '$_PR_NUMBER']
 

--- a/udfs/cloudbuild.yaml
+++ b/udfs/cloudbuild.yaml
@@ -23,7 +23,7 @@ steps:
 ###########################################################
 # Step 2: Deploy if all tests pass
 ###########################################################
-- name: gcr.io/cloud-builders/gcloud
+- name: gcr.io/google.com/cloudsdktool/cloud-sdk
   entrypoint: 'bash'
   args: ['release/build.sh', '$BRANCH_NAME', '$_PR_NUMBER']
 


### PR DESCRIPTION
Updating to use the cloud sdk image hosted on docker according to guidance from https://github.com/GoogleCloudPlatform/cloud-builders/issues/638