### PR TITLE
SQL Extractor: java examples, cli, file list expander and unit tests

### DIFF
--- a/tools/sql_extraction/README.md
+++ b/tools/sql_extraction/README.md
@@ -6,9 +6,47 @@ This directory contains a command-line application that can
 
 It can be used to locate embedded SQL query strings in your repository while migrating to a new database.
 
+## Usage
+
+```
+Usage: sql_extraction [OPTIONS] [FILEPATHS]...
+
+  Sample Usages:
+
+  > sql_extraction path/to/file.java
+  > sql_extraction -r path/to/directory path/to/another/directory path/to/file.java
+  > sql_extraction --include="*.java" path/to/directory
+  > sql_extraction -r --include="*.java" --include="*.cs" .
+  > sql_extraction -r --exclude="*.cs" /
+
+Options:
+  -R, -r, --recursive  scan files in subdirectories recursively
+  --include GLOB       Search only files whose base name matches GLOB
+  --exclude GLOB       Skip files whose base name matches GLOB
+  -h, --help           Show this message and exit
+
+Arguments:
+  FILEPATHS  file and directory paths to code
+```
+
 ## Building
 
+To run:
+```
+./gradlew run --args="[ARGUMENTS]"
+```
+
+To build:
 ```
 ./gradlew run
 ```
 
+To clean build artifacts:
+```
+./gradlew clean
+```
+
+To run tests:
+```
+./gradlew test
+```

--- a/tools/sql_extraction/build.gradle.kts
+++ b/tools/sql_extraction/build.gradle.kts
@@ -8,8 +8,12 @@ plugins {
 group = "com.google.cloud.sqlecosystem"
 version = "1.0"
 
+// clean task = clean
+// build task = build
+// build and run task = run
+// test task = test
 application {
-    mainClassName = "com.google.cloud.sqlecosystem.sqlextraction.AppKt"
+    mainClassName = "com.google.cloud.sqlecosystem.sqlextraction.CliKt"
 }
 
 repositories {
@@ -22,6 +26,13 @@ dependencies {
     implementation("org.slf4j:slf4j-simple:1.7.29")
     antlr("org.antlr:antlr4:4.7.2")
     implementation("org.antlr:antlr4-runtime:4.7.2")
+    implementation("com.github.ajalt:clikt:2.7.1")
+    implementation("com.google.code.gson:gson:2.8.5")
+
+    testImplementation(kotlin("test"))
+    testImplementation(kotlin("test-junit"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
+    testImplementation("com.google.jimfs:jimfs:1.1")
 }
 
 task<de.undercouch.gradle.tasks.download.Download>("downloadGrammars") {
@@ -31,6 +42,7 @@ task<de.undercouch.gradle.tasks.download.Download>("downloadGrammars") {
     }
     src(listOf("https://raw.githubusercontent.com/antlr/grammars-v4/master/java/java9/Java9.g4"))
     dest("gen/main/antlr/")
+    overwrite(false) // no need to download a copy every time
     println(System.getProperty("user.dir"))
 }
 

--- a/tools/sql_extraction/examples/ConcatTest.java
+++ b/tools/sql_extraction/examples/ConcatTest.java
@@ -1,0 +1,8 @@
+public class ConcatTest {
+    public String test() {
+        String sql = "SELECT *\n" +
+                " FROM customer\n" +
+                " WHERE a = 1 AND b = 1";
+        return sql;
+    }
+}

--- a/tools/sql_extraction/examples/IfElseTest.java
+++ b/tools/sql_extraction/examples/IfElseTest.java
@@ -1,0 +1,9 @@
+public class IfElseTest {
+    public String test(int i) {
+        String sql = "SELECT * FROM customer";
+        if (i > 0) {
+            sql += " WHERE id = " + i;
+        }
+        return sql;
+    }
+}

--- a/tools/sql_extraction/examples/JDBCTest.java
+++ b/tools/sql_extraction/examples/JDBCTest.java
@@ -1,0 +1,16 @@
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+public class JDBCTest {
+    private static final String URL = "jdbc:mysql://localhost/db";
+
+    public static void main(String[] args) {
+        Connection conn = DriverManager.getConnection(URL, "root", "root");
+        Statement stmt = conn.createStatement();
+
+        String sql = "SELECT * FROM customer";
+        ResultSet rs = stmt.executeQuery(sql);
+    }
+}

--- a/tools/sql_extraction/examples/LoopTest.java
+++ b/tools/sql_extraction/examples/LoopTest.java
@@ -1,0 +1,16 @@
+public class LoopTest {
+    public String test() {
+        String cities = {"Austin", "Beijing", "Cairo"};
+        String sql = "SELECT * FROM customer WHERE ";
+        boolean includeOr = false;
+        for (String city : cities) {
+            if (includeOr) {
+                sql += " OR ";
+            } else {
+                includeOr = true;
+            }
+            sql += "city = " + city;
+        }
+        return sql;
+    }
+}

--- a/tools/sql_extraction/examples/SimpleStringTest.java
+++ b/tools/sql_extraction/examples/SimpleStringTest.java
@@ -1,0 +1,7 @@
+public class SimpleStringTest {
+    public String test() {
+        System.out.println("This string is not an SQL query");
+        String sql = "SELECT * FROM customer";
+        return sql;
+    }
+}

--- a/tools/sql_extraction/src/main/kotlin/App.kt
+++ b/tools/sql_extraction/src/main/kotlin/App.kt
@@ -1,9 +1,0 @@
-package com.google.cloud.sqlecosystem.sqlextraction
-
-import mu.KotlinLogging
-
-private val logger = KotlinLogging.logger { }
-
-fun main(args: Array<String>) {
-    logger.debug("hello world!")
-}

--- a/tools/sql_extraction/src/main/kotlin/Cli.kt
+++ b/tools/sql_extraction/src/main/kotlin/Cli.kt
@@ -1,0 +1,59 @@
+package com.google.cloud.sqlecosystem.sqlextraction
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.multiple
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.multiple
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.path
+import mu.KotlinLogging
+import java.nio.file.Path
+
+private val logger = KotlinLogging.logger { }
+
+fun main(args: Array<String>) = Cli().main(args)
+
+class Cli : CliktCommand(
+    name = "sql_extraction",
+    printHelpOnEmptyArgs = true,
+    help = """
+    Command line application to extract raw SQL query strings and their usage within code.
+    
+    Sample Usages:
+    ```
+    > sql_extraction path/to/file.java
+    > sql_extraction -r path/to/directory path/to/another/directory path/to/file.java
+    > sql_extraction --include="*.java" path/to/directory
+    > sql_extraction -r --include="*.java" --include="*.cs" .
+    > sql_extraction -r --exclude="*.cs" /
+    ```
+    """
+) {
+    val recursive: Boolean by option(
+        "-R", "-r", "--recursive",
+        help = "scan files in subdirectories recursively"
+    ).flag()
+    val filePaths: List<Path> by argument(help = "file and directory paths to analyze").path(
+        mustExist = true,
+        canBeDir = true,
+        canBeFile = true
+    ).multiple()
+    val includes: List<String> by option(
+        "--include",
+        metavar = "GLOB",
+        help = "Search only files whose base name matches GLOB"
+    ).multiple()
+    val excludes: List<String> by option(
+        "--exclude",
+        metavar = "GLOB",
+        help = "Skip files whose base name matches GLOB"
+    ).multiple()
+
+    override fun run() {
+        logger.debug("Starting SQL Extraction from command line")
+
+        val files = FileListExpander().expandAndFilter(filePaths, recursive, includes, excludes)
+        logger.debug { "Files to analyze: $files" }
+    }
+}

--- a/tools/sql_extraction/src/main/kotlin/FileListExpander.kt
+++ b/tools/sql_extraction/src/main/kotlin/FileListExpander.kt
@@ -1,0 +1,35 @@
+package com.google.cloud.sqlecosystem.sqlextraction
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.stream.Collectors
+
+class FileListExpander {
+    fun expandAndFilter(
+        dirs: Collection<Path>,
+        recursive: Boolean = false,
+        includes: List<String> = emptyList(),
+        excludes: List<String> = emptyList()
+    ): Collection<Path> {
+        assert(!dirs.isEmpty()) { "dirs cannot be empty" }
+
+        val fileSystem = dirs.first().fileSystem
+        val includeMatchers = includes.map { fileSystem.getPathMatcher("glob:$it") }
+        val excludeMatchers = excludes.map { fileSystem.getPathMatcher("glob:$it") }
+
+        return dirs.stream().flatMap { basePath ->
+            Files.walk(basePath, if (recursive) Int.MAX_VALUE else 1)
+                .filter { Files.isRegularFile(it) }
+                .filter { path ->
+                    includeMatchers.isEmpty() || includeMatchers.any { matcher ->
+                        matcher.matches(path) || matcher.matches(path.fileName)
+                    }
+                }
+                .filter { path ->
+                    excludeMatchers.isEmpty() || !excludeMatchers.any { matcher ->
+                        matcher.matches(path) || matcher.matches(path.fileName)
+                    }
+                }
+        }.collect(Collectors.toSet())
+    }
+}

--- a/tools/sql_extraction/src/test/kotlin/FileListExpanderTest.kt
+++ b/tools/sql_extraction/src/test/kotlin/FileListExpanderTest.kt
@@ -1,0 +1,177 @@
+package com.google.cloud.sqlecosystem.sqlextraction
+
+import com.google.common.jimfs.Configuration
+import com.google.common.jimfs.Jimfs
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class FileListExpanderTest {
+    val expander = FileListExpander()
+
+    @Test
+    fun `all files are included`() {
+        val fs = Jimfs.newFileSystem(Configuration.unix())
+        val fileA = fs.getPath("/a.java")
+        val fileB = fs.getPath("/b.java")
+        Files.createFile(fileA)
+        Files.createFile(fileB)
+
+        val result = expander.expandAndFilter(listOf(fileA, fileB), false)
+
+        assertEquals(setOf(fileA, fileB), result)
+    }
+
+    @Test
+    fun `files within directories included`() {
+        val fs = Jimfs.newFileSystem(Configuration.unix())
+        Files.createDirectories(fs.getPath("/dir"))
+        val fileA = fs.getPath("/dir/a.java")
+        val fileB = fs.getPath("/dir/b.java")
+        Files.createFile(fileA)
+        Files.createFile(fileB)
+
+        val result = expander.expandAndFilter(listOf(fs.getPath("/dir")), false)
+
+        assertEquals(setOf(fileA, fileB), result)
+    }
+
+    @Test
+    fun `files within subdirectories are not included without recursive`() {
+        val fs = Jimfs.newFileSystem(Configuration.unix())
+        Files.createDirectories(fs.getPath("/dir"))
+        Files.createDirectories(fs.getPath("/dir/subdir"))
+        val fileA = fs.getPath("/dir/a.java")
+        val fileB = fs.getPath("/dir/subdir/b.java")
+        Files.createFile(fileA)
+        Files.createFile(fileB)
+
+        val result = expander.expandAndFilter(listOf(fs.getPath("/dir")), false)
+
+        assertEquals(setOf(fileA), result)
+    }
+
+    @Test
+    fun `files within subdirectories are included with recursive`() {
+        val fs = Jimfs.newFileSystem(Configuration.unix())
+        Files.createDirectories(fs.getPath("/dir"))
+        Files.createDirectories(fs.getPath("/dir/subdir"))
+        val fileA = fs.getPath("/dir/a.java")
+        val fileB = fs.getPath("/dir/subdir/b.java")
+        Files.createFile(fileA)
+        Files.createFile(fileB)
+
+        val result = expander.expandAndFilter(listOf(fs.getPath("/dir")), true)
+
+        assertEquals(setOf(fileA, fileB), result)
+    }
+
+    @Test
+    fun `returned collection doesn't have duplicates`() {
+        val fs = Jimfs.newFileSystem(Configuration.unix())
+        val fileA = fs.getPath("/a.java")
+        Files.createFile(fileA)
+
+        val result = expander.expandAndFilter(listOf(fileA, fileA), false)
+
+        assertTrue(result.size == 1)
+    }
+
+    @Test
+    fun `include filters out by GLOB`() {
+        val fs = Jimfs.newFileSystem(Configuration.unix())
+        val fileA = fs.getPath("/a.java")
+        val fileB = fs.getPath("/a.notjava")
+        Files.createFile(fileA)
+        Files.createFile(fileB)
+
+        val result = expander.expandAndFilter(listOf(fs.getPath("/")), false, includes = listOf("*.java"))
+
+        assertEquals(setOf(fileA), result)
+    }
+
+    @Test
+    fun `multiple includes take the union`() {
+        val fs = Jimfs.newFileSystem(Configuration.unix())
+        val fileA = fs.getPath("/a.java")
+        val fileB = fs.getPath("/a.maybejava")
+        val fileC = fs.getPath("/a.notjava")
+        Files.createFile(fileA)
+        Files.createFile(fileB)
+        Files.createFile(fileC)
+
+        val result =
+            expander.expandAndFilter(listOf(fs.getPath("/")), false, includes = listOf("*.java", "*.maybejava"))
+
+        assertEquals(setOf(fileA, fileB), result)
+    }
+
+    @Test
+    fun `exclude filters out by GLOB`() {
+        val fs = Jimfs.newFileSystem(Configuration.unix())
+        val fileA = fs.getPath("/a.java")
+        val fileB = fs.getPath("/a.notjava")
+        Files.createFile(fileA)
+        Files.createFile(fileB)
+
+        val result = expander.expandAndFilter(listOf(fs.getPath("/")), false, excludes = listOf("*.notjava"))
+
+        assertEquals(setOf(fileA), result)
+    }
+
+    @Test
+    fun `multiple excludes subtract the union`() {
+        val fs = Jimfs.newFileSystem(Configuration.unix())
+        val fileA = fs.getPath("/a.java")
+        val fileB = fs.getPath("/a.maybejava")
+        val fileC = fs.getPath("/a.notjava")
+        Files.createFile(fileA)
+        Files.createFile(fileB)
+        Files.createFile(fileC)
+
+        val result =
+            expander.expandAndFilter(listOf(fs.getPath("/")), false, excludes = listOf("*.notjava", "*.maybejava"))
+
+        assertEquals(setOf(fileA), result)
+    }
+
+    @Test
+    fun `includes and excludes work together`() {
+        val fs = Jimfs.newFileSystem(Configuration.unix())
+        val fileA = fs.getPath("/1.java")
+        val fileB = fs.getPath("/2.java")
+        val fileC = fs.getPath("/3.notjava")
+        Files.createFile(fileA)
+        Files.createFile(fileB)
+        Files.createFile(fileC)
+
+        val result = expander.expandAndFilter(
+            listOf(fs.getPath("/")),
+            false,
+            includes = listOf("*.java"),
+            excludes = listOf("2.*")
+        )
+
+        assertEquals(setOf(fileA), result)
+    }
+
+    @Test
+    fun `include GLOB works in any directory`() {
+        val fs = Jimfs.newFileSystem(Configuration.unix())
+        Files.createDirectories(fs.getPath("/1"))
+        Files.createDirectories(fs.getPath("/2"))
+        val fileA = fs.getPath("/1/a.java")
+        val fileB = fs.getPath("/2/a.java")
+        val fileC = fs.getPath("/1/a.notjava")
+        val fileD = fs.getPath("/2/a.notjava")
+        Files.createFile(fileA)
+        Files.createFile(fileB)
+        Files.createFile(fileC)
+        Files.createFile(fileD)
+
+        val result = expander.expandAndFilter(listOf(fs.getPath("/")), true, includes = listOf("*.java"))
+
+        assertEquals(setOf(fileA, fileB), result)
+    }
+}

--- a/tools/sql_extraction/src/test/resources/junit-platform.properties
+++ b/tools/sql_extraction/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.testinstance.lifecycle.default=per_class


### PR DESCRIPTION
- added `examples` directory with java files to use as example inputs
- added a command line arguments library, with current options following:
```
Usage: sql_extraction [OPTIONS] [FILEPATHS]...

Options:
  -r, --recursive  scan files in subdirectories recursively
  -h, --help       Show this message and exit

Arguments:
  FILEPATHS  file and directory paths to code
```
- added basic file list expander (converts directories to list of files) and unit tests

Support for features such as globs/file extension support will be added in a future commit