### PR TITLE
SQL Extraction: setup data pipeline (frontends, json output)

### DIFF
--- a/tools/sql_extraction/README.md
+++ b/tools/sql_extraction/README.md
@@ -11,6 +11,9 @@ It can be used to locate embedded SQL query strings in your repository while mig
 ```
 Usage: sql_extraction [OPTIONS] [FILEPATHS]...
 
+  Command line application to extract raw SQL query strings and their usage
+  within code.
+
   Sample Usages:
 
   > sql_extraction path/to/file.java
@@ -20,13 +23,14 @@ Usage: sql_extraction [OPTIONS] [FILEPATHS]...
   > sql_extraction -r --exclude="*.cs" /
 
 Options:
-  -R, -r, --recursive  scan files in subdirectories recursively
+  -R, -r, --recursive  Scan files in subdirectories recursively
   --include GLOB       Search only files whose base name matches GLOB
   --exclude GLOB       Skip files whose base name matches GLOB
+  --pretty             Pretty-print output JSON
   -h, --help           Show this message and exit
 
 Arguments:
-  FILEPATHS  file and directory paths to code
+  FILEPATHS  File and directory paths to analyze
 ```
 
 ## Building

--- a/tools/sql_extraction/build.gradle.kts
+++ b/tools/sql_extraction/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     testImplementation(kotlin("test-junit"))
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
     testImplementation("com.google.jimfs:jimfs:1.1")
+    testImplementation("io.mockk:mockk:1.10.0")
 }
 
 task<de.undercouch.gradle.tasks.download.Download>("downloadGrammars") {
@@ -49,7 +50,11 @@ task<de.undercouch.gradle.tasks.download.Download>("downloadGrammars") {
 tasks {
     generateGrammarSource {
         dependsOn("downloadGrammars")
-        arguments = arguments + listOf("-package", "com.google.cloud.sqlecosystem.sqlextraction.antlr")
+        arguments = arguments + listOf(
+            "-package", "com.google.cloud.sqlecosystem.sqlextraction.antlr",
+            "-visitor",
+            "-no-listener"
+        )
         include("*.g4")
         source("gen/main/antlr")
         outputDirectory = File("gen/main/antlr")

--- a/tools/sql_extraction/src/main/kotlin/DataFlowEngine.kt
+++ b/tools/sql_extraction/src/main/kotlin/DataFlowEngine.kt
@@ -1,0 +1,7 @@
+package com.google.cloud.sqlecosystem.sqlextraction
+
+/**
+ * Backend engine for running data-flow analysis
+ * @see FrontEnd
+ */
+class DataFlowEngine

--- a/tools/sql_extraction/src/main/kotlin/DataFlowSolver.kt
+++ b/tools/sql_extraction/src/main/kotlin/DataFlowSolver.kt
@@ -1,0 +1,33 @@
+package com.google.cloud.sqlecosystem.sqlextraction
+
+import com.google.cloud.sqlecosystem.sqlextraction.output.Query
+import mu.KotlinLogging
+import java.nio.file.Path
+
+private val LOGGER = KotlinLogging.logger { }
+
+/**
+ * Detects SQL query construction and usages
+ *
+ * @param[frontends] List of language-specific frontends to support during data-flow analysis
+ */
+class DataFlowSolver(private val frontends: List<FrontEnd>) {
+    /**
+     * Finds all SQL query construction and usages in the given [filePath]
+     *
+     * @param[engine] Engine to analyze the file with
+     * @return Detected queries
+     * @throws[IllegalArgumentException] If the given file cannot be
+     *     analyzed by any registered frontend
+     */
+    fun solveDataFlow(engine: DataFlowEngine, filePath: Path): Sequence<Query> {
+        for (frontEnd in frontends) {
+            if (frontEnd.canSolve(filePath)) {
+                LOGGER.debug { "Using ${frontEnd.javaClass.simpleName} for $filePath" }
+                return frontEnd.solveDataFlow(engine, frontEnd.openFile(filePath))
+            }
+        }
+
+        throw IllegalArgumentException("Cannot analyze $filePath. No frontend available.")
+    }
+}

--- a/tools/sql_extraction/src/main/kotlin/FileListExpander.kt
+++ b/tools/sql_extraction/src/main/kotlin/FileListExpander.kt
@@ -4,7 +4,20 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.util.stream.Collectors
 
+/**
+ * Expands a collection of file and directory paths to a list of all applicable file paths
+ */
 class FileListExpander {
+    /**
+     * Converts a collection of file and directory paths to all applicable file paths
+     *
+     * @param[dirs] File and directory paths to consider
+     * @param[recursive] True of visit subdirectories recursively,
+     *     false to only visit the top-level directories
+     * @param[includes] List of GLOB patterns to limit added output file paths
+     * @param[excludes] List of GLOB patterns to filter out output file paths
+     * @return Expanded and filtered collection of file paths to analyze
+     */
     fun expandAndFilter(
         dirs: Collection<Path>,
         recursive: Boolean = false,
@@ -30,6 +43,6 @@ class FileListExpander {
                         matcher.matches(path) || matcher.matches(path.fileName)
                     }
                 }
-        }.collect(Collectors.toSet())
+        }.collect(Collectors.toSet()) // todo: return as distinct stream
     }
 }

--- a/tools/sql_extraction/src/main/kotlin/FrontEnd.kt
+++ b/tools/sql_extraction/src/main/kotlin/FrontEnd.kt
@@ -1,0 +1,32 @@
+package com.google.cloud.sqlecosystem.sqlextraction
+
+import com.google.cloud.sqlecosystem.sqlextraction.output.Query
+import org.antlr.v4.runtime.CharStream
+import org.antlr.v4.runtime.CharStreams
+import java.nio.file.Path
+
+/**
+ * Language-specific module to run data-flow analysis in the AST level
+ *
+ * @see DataFlowEngine
+ */
+interface FrontEnd {
+    /**
+     * Checks whether the given [filePath] can be analyzed by this frontend
+     */
+    fun canSolve(filePath: Path): Boolean
+
+    /**
+     * Opens the given [filePath] as a CharStream
+     */
+    fun openFile(filePath: Path): CharStream {
+        return CharStreams.fromPath(filePath)
+    }
+
+    /**
+     * Solves data-flow analysis using the given [engine] for the given [fileStream]
+     *
+     * @return Detected queries
+     */
+    fun solveDataFlow(engine: DataFlowEngine, fileStream: CharStream): Sequence<Query>
+}

--- a/tools/sql_extraction/src/main/kotlin/JavaFrontEnd.kt
+++ b/tools/sql_extraction/src/main/kotlin/JavaFrontEnd.kt
@@ -1,0 +1,29 @@
+package com.google.cloud.sqlecosystem.sqlextraction
+
+import com.google.cloud.sqlecosystem.sqlextraction.antlr.Java9Lexer
+import com.google.cloud.sqlecosystem.sqlextraction.antlr.Java9Parser
+import com.google.cloud.sqlecosystem.sqlextraction.output.Query
+import org.antlr.v4.runtime.CharStream
+import org.antlr.v4.runtime.CommonTokenStream
+import org.antlr.v4.runtime.TokenSource
+import org.antlr.v4.runtime.TokenStream
+import java.nio.file.Path
+
+/**
+ * Data-flow analysis frontend for Java (.java files)
+ */
+class JavaFrontEnd : FrontEnd {
+    override fun canSolve(filePath: Path): Boolean {
+        return filePath.toString().endsWith(".java", ignoreCase = true)
+    }
+
+    override fun solveDataFlow(engine: DataFlowEngine, fileStream: CharStream): Sequence<Query> {
+        val lexer = Java9Lexer(fileStream)
+        val tokens = CommonTokenStream(lexer as TokenSource)
+        val parser = Java9Parser(tokens as TokenStream)
+        // todo: analyze compilationUnit
+        parser.compilationUnit()
+
+        return emptySequence()
+    }
+}

--- a/tools/sql_extraction/src/main/kotlin/SqlExtractor.kt
+++ b/tools/sql_extraction/src/main/kotlin/SqlExtractor.kt
@@ -1,0 +1,28 @@
+package com.google.cloud.sqlecosystem.sqlextraction
+
+import com.google.cloud.sqlecosystem.sqlextraction.output.Output
+import com.google.cloud.sqlecosystem.sqlextraction.output.Query
+import mu.KotlinLogging
+import java.nio.file.Path
+
+private val LOGGER = KotlinLogging.logger { }
+
+/**
+ * Extracts SQL queries using the given solver
+ *
+ * @param[dataFlowSolver] Solver responsible for detecting query construction and usages
+ */
+class SqlExtractor(private val dataFlowSolver: DataFlowSolver) {
+    /**
+     * @return Detected SQL queries sorted by confidence
+     */
+    fun process(filePaths: Collection<Path>): Output {
+        val queries = ArrayList<Query>()
+        for (filePath in filePaths) {
+            LOGGER.debug { "Scanning $filePath" }
+            queries.addAll(dataFlowSolver.solveDataFlow(DataFlowEngine(), filePath))
+        }
+
+        return Output(queries)
+    }
+}

--- a/tools/sql_extraction/src/main/kotlin/output/Location.kt
+++ b/tools/sql_extraction/src/main/kotlin/output/Location.kt
@@ -1,0 +1,39 @@
+package com.google.cloud.sqlecosystem.sqlextraction.output
+
+import java.lang.Integer.max
+import java.lang.Integer.min
+
+/**
+ * All values inclusive
+ */
+data class Location(
+    val startLine: Int,
+    val startColumn: Int,
+    val endLine: Int,
+    val endColumn: Int
+) {
+    companion object {
+        /** Returns the union of [a] and [b] */
+        fun combine(a: Location, b: Location): Location {
+            return Location(
+                startLine = min(a.startLine, b.startLine),
+                startColumn = when {
+                    a.startLine < b.startLine -> a.startColumn
+                    a.startLine > b.startLine -> b.startColumn
+                    else -> min(a.startColumn, b.startColumn)
+                },
+                endLine = max(a.endLine, b.endLine),
+                endColumn = when {
+                    a.endLine > b.endLine -> a.endColumn
+                    a.endLine < b.endLine -> b.endColumn
+                    else -> max(a.endColumn, b.endColumn)
+                }
+            )
+        }
+
+        /** Reduces [locations] into the union using [combine] */
+        fun combine(locations: Iterable<Location>): Location {
+            return locations.reduce { a, b -> combine(a, b) }
+        }
+    }
+}

--- a/tools/sql_extraction/src/main/kotlin/output/Output.kt
+++ b/tools/sql_extraction/src/main/kotlin/output/Output.kt
@@ -1,0 +1,3 @@
+package com.google.cloud.sqlecosystem.sqlextraction.output
+
+data class Output(val queries: List<Query>)

--- a/tools/sql_extraction/src/main/kotlin/output/Query.kt
+++ b/tools/sql_extraction/src/main/kotlin/output/Query.kt
@@ -1,0 +1,9 @@
+package com.google.cloud.sqlecosystem.sqlextraction.output
+
+data class Query(
+    val file: String,
+    val confidence: Double,
+    val query: QueryFragment,
+    val usages: List<Location>,
+    val notes: String? = null
+)

--- a/tools/sql_extraction/src/main/kotlin/output/QueryFragment.kt
+++ b/tools/sql_extraction/src/main/kotlin/output/QueryFragment.kt
@@ -1,0 +1,50 @@
+package com.google.cloud.sqlecosystem.sqlextraction.output
+
+enum class FragmentCount { SINGLE, OPTIONAL, MULTIPLE, UNKNOWN }
+enum class ComplexType { AND, OR, UNKNOWN }
+
+data class QueryFragment(
+    val count: FragmentCount = FragmentCount.SINGLE,
+    var location: Location,
+    val literal: String? = null,
+    val complex: MutableList<QueryFragment>? = null,
+    val type: ComplexType? = null
+) {
+    companion object {
+        fun createLiteral(
+            count: FragmentCount,
+            location: Location,
+            literal: String
+        ) = QueryFragment(count, location, literal)
+
+        fun createComplex(
+            count: FragmentCount,
+            complex: Iterable<QueryFragment>,
+            type: ComplexType = ComplexType.UNKNOWN
+        ) = QueryFragment(
+            count = count,
+            location = Location.combine(complex.map { it.location }),
+            complex = complex.toMutableList(),
+            type = type
+        )
+
+        /**
+         * Combines [base] and [addition] into a complex fragment
+         * either by mutating [base] or by returning a newly created fragment
+         */
+        fun combine(
+            count: FragmentCount,
+            base: QueryFragment,
+            addition: QueryFragment,
+            type: ComplexType = ComplexType.UNKNOWN
+        ): QueryFragment {
+            return if (base.type != type || base.count != count) {
+                createComplex(count, listOf(base, addition), type)
+            } else {
+                base.location = Location.combine(base.location, addition.location)
+                base.complex!!.add(addition)
+                base
+            }
+        }
+    }
+}

--- a/tools/sql_extraction/src/test/kotlin/DataFlowSolverTest.kt
+++ b/tools/sql_extraction/src/test/kotlin/DataFlowSolverTest.kt
@@ -1,0 +1,76 @@
+package com.google.cloud.sqlecosystem.sqlextraction
+
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifySequence
+import org.antlr.v4.runtime.CharStream
+import org.junit.jupiter.api.assertThrows
+import java.nio.file.Path
+import kotlin.test.Test
+
+class DataFlowSolverTest {
+    @Test
+    fun `solver throws without any frontends`() {
+        val solver = DataFlowSolver(emptyList())
+
+        assertThrows<IllegalArgumentException> { solver.solveDataFlow(mockk(relaxed = true), mockk(relaxed = true)) }
+    }
+
+    @Test
+    fun `solver calls canSolve, openFile, and solveDataFlow for a valid frontend`() {
+        val filePath = mockk<Path>(relaxed = true)
+        val stream = mockk<CharStream>(relaxed = true)
+
+        val frontEnd = mockk<FrontEnd>()
+        every { frontEnd.canSolve(any()) } returns true
+        every { frontEnd.openFile(any()) } returns stream
+        every { frontEnd.solveDataFlow(any(), any()) } returns emptySequence()
+
+        val solver = DataFlowSolver(listOf(frontEnd))
+        solver.solveDataFlow(mockk(relaxed = true), filePath)
+
+        verifySequence {
+            frontEnd.canSolve(filePath)
+            frontEnd.openFile(filePath)
+            frontEnd.solveDataFlow(any(), stream)
+        }
+        confirmVerified()
+    }
+
+    @Test
+    fun `solver throws without any valid frontends`() {
+        val frontEnd = mockk<FrontEnd>()
+        every { frontEnd.canSolve(any()) } returns false
+
+        val solver = DataFlowSolver(listOf(frontEnd))
+
+        assertThrows<IllegalArgumentException> { solver.solveDataFlow(mockk(relaxed = true), mockk(relaxed = true)) }
+    }
+
+    @Test
+    fun `solver only uses a valid frontend`() {
+        val filePath = mockk<Path>(relaxed = true)
+        val stream = mockk<CharStream>(relaxed = true)
+
+        val invalidFrontEnd = mockk<FrontEnd>()
+        every { invalidFrontEnd.canSolve(any()) } returns false
+
+        val frontEnd = mockk<FrontEnd>()
+        every { frontEnd.canSolve(any()) } returns true
+        every { frontEnd.openFile(any()) } returns stream
+        every { frontEnd.solveDataFlow(any(), any()) } returns emptySequence()
+
+        val solver = DataFlowSolver(listOf(invalidFrontEnd, frontEnd))
+        solver.solveDataFlow(mockk(relaxed = true), filePath)
+
+        verify(inverse = true) { invalidFrontEnd.solveDataFlow(any(), any()) }
+        verifySequence {
+            frontEnd.canSolve(filePath)
+            frontEnd.openFile(filePath)
+            frontEnd.solveDataFlow(any(), stream)
+        }
+        confirmVerified()
+    }
+}

--- a/tools/sql_extraction/src/test/kotlin/SqlExtractorTest.kt
+++ b/tools/sql_extraction/src/test/kotlin/SqlExtractorTest.kt
@@ -1,0 +1,35 @@
+package com.google.cloud.sqlecosystem.sqlextraction
+
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyAll
+import java.nio.file.Path
+import kotlin.test.Test
+
+class SqlExtractorTest {
+    @Test
+    fun `given data-flow solver is used`() {
+        val solver = mockk<DataFlowSolver>()
+        every { solver.solveDataFlow(any(), any()) } returns emptySequence()
+
+        SqlExtractor(solver).process(listOf(mockk(relaxed = true)))
+        verify { solver.solveDataFlow(any(), any()) }
+
+        confirmVerified()
+    }
+
+    @Test
+    fun `given data-flow solver is used for each path`() {
+        val solver = mockk<DataFlowSolver>()
+        every { solver.solveDataFlow(any(), any()) } returns emptySequence()
+
+        val filePaths = listOf<Path>(mockk(relaxed = true), mockk(relaxed = true), mockk(relaxed = true))
+
+        SqlExtractor(solver).process(filePaths)
+        verifyAll { filePaths.map { solver.solveDataFlow(any(), it) } }
+
+        confirmVerified()
+    }
+}

--- a/tools/sql_extraction/src/test/resources/simplelogger.properties
+++ b/tools/sql_extraction/src/test/resources/simplelogger.properties
@@ -4,7 +4,7 @@
 # Default logging detail level for all instances of SimpleLogger.
 # Must be one of ("trace", "debug", "info", "warn", or "error").
 # If not specified, defaults to "info".
-org.slf4j.simpleLogger.defaultLogLevel=debug
+org.slf4j.simpleLogger.defaultLogLevel=info
 
 # Logging detail level for a SimpleLogger instance named "xxxxx".
 # Must be one of ("trace", "debug", "info", "warn", or "error").


### PR DESCRIPTION
To analyze each file, both a frontend and a data-flow engine are required. The frontend reads through the language-specific AST in program order and calls necessary methods in the engine (e.g. foundLiteral, foundUsage, etc). The AST parser and visitor are provided by Antlr. Since this commit was getting massive, the engine implementation and other details will be on a future commit.

Resulting list of queries are converted to JSON and printed to STDOUT.