### PR TITLE
SQL Extraction: refactor to use sequences

### DIFF
--- a/tools/sql_extraction/README.md
+++ b/tools/sql_extraction/README.md
@@ -42,7 +42,7 @@ To run:
 
 To build:
 ```
-./gradlew run
+./gradlew build
 ```
 
 To clean build artifacts:

--- a/tools/sql_extraction/src/main/kotlin/Cli.kt
+++ b/tools/sql_extraction/src/main/kotlin/Cli.kt
@@ -7,6 +7,7 @@ import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.path
+import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import mu.KotlinLogging
 import java.nio.file.Path
@@ -14,7 +15,7 @@ import java.nio.file.Path
 private val LOGGER = KotlinLogging.logger { }
 
 fun main(args: Array<String>) = Cli(
-    FileListExpander(),
+    FilesExpander(),
     SqlExtractor(
         DataFlowSolver(
             listOf(
@@ -25,7 +26,7 @@ fun main(args: Array<String>) = Cli(
 ).main(args)
 
 private class Cli(
-    private val fileListExpander: FileListExpander,
+    private val filesExpander: FilesExpander,
     private val sqlExtractor: SqlExtractor
 ) :
     CliktCommand(
@@ -76,10 +77,10 @@ private class Cli(
     override fun run() {
         LOGGER.debug("Starting SQL Extraction from command line")
 
-        val files = fileListExpander.expandAndFilter(filePaths, recursive, includes, excludes)
-        LOGGER.debug { "Files to analyze: $files" }
+        val files = filesExpander.expandAndFilter(filePaths, recursive, includes, excludes)
 
         val output = sqlExtractor.process(files)
+        LOGGER.debug { "output: ${Gson().toJson(output)}" }
 
         val builder = GsonBuilder()
         if (prettyPrint) {
@@ -87,7 +88,6 @@ private class Cli(
         }
         val json = builder.create().toJson(output)
 
-        LOGGER.debug { "output: $json" }
         println(json)
     }
 }

--- a/tools/sql_extraction/src/main/kotlin/DataFlowEngine.kt
+++ b/tools/sql_extraction/src/main/kotlin/DataFlowEngine.kt
@@ -20,7 +20,12 @@ class DataFlowEngine {
             .map { QueryUsages(it.key, it.value.sorted()) }
     }
 
-    private fun registerUsage(usage: Location, query: QueryFragment) {
+    /**
+     * Marks [usage] as one of the part of code where [query] is used.
+     *
+     * Usage examples: method call argument, return, added to non-local data structure, etc
+     */
+    private fun addUsage(query: QueryFragment, usage: Location) {
         queryUsages.computeIfAbsent(query) { HashSet() }.add(usage)
     }
 }

--- a/tools/sql_extraction/src/main/kotlin/DataFlowEngine.kt
+++ b/tools/sql_extraction/src/main/kotlin/DataFlowEngine.kt
@@ -1,7 +1,26 @@
 package com.google.cloud.sqlecosystem.sqlextraction
 
+import com.google.cloud.sqlecosystem.sqlextraction.output.Location
+import com.google.cloud.sqlecosystem.sqlextraction.output.QueryFragment
+import com.google.cloud.sqlecosystem.sqlextraction.output.QueryUsages
+
 /**
  * Backend engine for running data-flow analysis
  * @see FrontEnd
  */
-class DataFlowEngine
+class DataFlowEngine {
+    private val queryUsages: HashMap<QueryFragment, HashSet<Location>> = HashMap()
+
+    /**
+     * Returns all query fragments and usages found by the engine thus far
+     */
+    fun getAllQueries(): Sequence<QueryUsages> {
+        return queryUsages.asSequence()
+            .filter { it.value.isNotEmpty() }
+            .map { QueryUsages(it.key, it.value.sorted()) }
+    }
+
+    private fun registerUsage(usage: Location, query: QueryFragment) {
+        queryUsages.computeIfAbsent(query) { HashSet() }.add(usage)
+    }
+}

--- a/tools/sql_extraction/src/main/kotlin/DataFlowSolver.kt
+++ b/tools/sql_extraction/src/main/kotlin/DataFlowSolver.kt
@@ -1,6 +1,6 @@
 package com.google.cloud.sqlecosystem.sqlextraction
 
-import com.google.cloud.sqlecosystem.sqlextraction.output.Query
+import com.google.cloud.sqlecosystem.sqlextraction.output.QueryUsages
 import mu.KotlinLogging
 import java.nio.file.Path
 
@@ -20,11 +20,12 @@ class DataFlowSolver(private val frontends: List<FrontEnd>) {
      * @throws[IllegalArgumentException] If the given file cannot be
      *     analyzed by any registered frontend
      */
-    fun solveDataFlow(engine: DataFlowEngine, filePath: Path): Sequence<Query> {
+    fun solveDataFlow(engine: DataFlowEngine, filePath: Path): Sequence<QueryUsages> {
         for (frontEnd in frontends) {
             if (frontEnd.canSolve(filePath)) {
                 LOGGER.debug { "Using ${frontEnd.javaClass.simpleName} for $filePath" }
-                return frontEnd.solveDataFlow(engine, frontEnd.openFile(filePath))
+                frontEnd.solveDataFlow(engine, frontEnd.openFile(filePath))
+                return engine.getAllQueries()
             }
         }
 

--- a/tools/sql_extraction/src/main/kotlin/FrontEnd.kt
+++ b/tools/sql_extraction/src/main/kotlin/FrontEnd.kt
@@ -25,8 +25,6 @@ interface FrontEnd {
 
     /**
      * Solves data-flow analysis using the given [engine] for the given [fileStream]
-     *
-     * @return Detected queries
      */
-    fun solveDataFlow(engine: DataFlowEngine, fileStream: CharStream): Sequence<Query>
+    fun solveDataFlow(engine: DataFlowEngine, fileStream: CharStream)
 }

--- a/tools/sql_extraction/src/main/kotlin/JavaFrontEnd.kt
+++ b/tools/sql_extraction/src/main/kotlin/JavaFrontEnd.kt
@@ -17,13 +17,11 @@ class JavaFrontEnd : FrontEnd {
         return filePath.toString().endsWith(".java", ignoreCase = true)
     }
 
-    override fun solveDataFlow(engine: DataFlowEngine, fileStream: CharStream): Sequence<Query> {
+    override fun solveDataFlow(engine: DataFlowEngine, fileStream: CharStream) {
         val lexer = Java9Lexer(fileStream)
         val tokens = CommonTokenStream(lexer as TokenSource)
         val parser = Java9Parser(tokens as TokenStream)
-        // todo: analyze compilationUnit
+        // todo: analyze compilationUnit using the engine
         parser.compilationUnit()
-
-        return emptySequence()
     }
 }

--- a/tools/sql_extraction/src/main/kotlin/SqlExtractor.kt
+++ b/tools/sql_extraction/src/main/kotlin/SqlExtractor.kt
@@ -16,11 +16,20 @@ class SqlExtractor(private val dataFlowSolver: DataFlowSolver) {
     /**
      * @return Detected SQL queries sorted by confidence
      */
-    fun process(filePaths: Collection<Path>): Output {
+    fun process(filePaths: Sequence<Path>): Output {
         val queries = ArrayList<Query>()
         for (filePath in filePaths) {
             LOGGER.debug { "Scanning $filePath" }
-            queries.addAll(dataFlowSolver.solveDataFlow(DataFlowEngine(), filePath))
+            queries.addAll(
+                dataFlowSolver.solveDataFlow(DataFlowEngine(), filePath)
+                    .map {
+                        Query(
+                            filePath.toString(),
+                            1.0, // todo: rank query confidence
+                            it.query,
+                            it.usages
+                        )
+                    })
         }
 
         return Output(queries)

--- a/tools/sql_extraction/src/main/kotlin/output/Location.kt
+++ b/tools/sql_extraction/src/main/kotlin/output/Location.kt
@@ -11,8 +11,13 @@ data class Location(
     val startColumn: Int,
     val endLine: Int,
     val endColumn: Int
-) {
+) : Comparable<Location> {
     companion object {
+        private val COMPARATOR = Comparator.comparingInt<Location> { it.startLine }
+            .thenComparingInt { it.startColumn }
+            .thenComparingInt { it.endLine }
+            .thenComparingInt { it.endColumn }
+
         /** Returns the union of [a] and [b] */
         fun combine(a: Location, b: Location): Location {
             return Location(
@@ -36,4 +41,6 @@ data class Location(
             return locations.reduce { a, b -> combine(a, b) }
         }
     }
+
+    override fun compareTo(other: Location) = COMPARATOR.compare(this, other)
 }

--- a/tools/sql_extraction/src/main/kotlin/output/Query.kt
+++ b/tools/sql_extraction/src/main/kotlin/output/Query.kt
@@ -7,3 +7,8 @@ data class Query(
     val usages: List<Location>,
     val notes: String? = null
 )
+
+data class QueryUsages(
+    val query: QueryFragment,
+    val usages: List<Location>
+)

--- a/tools/sql_extraction/src/main/kotlin/output/QueryFragment.kt
+++ b/tools/sql_extraction/src/main/kotlin/output/QueryFragment.kt
@@ -5,46 +5,54 @@ enum class ComplexType { AND, OR, UNKNOWN }
 
 data class QueryFragment(
     val count: FragmentCount = FragmentCount.SINGLE,
-    var location: Location,
+    val location: Location,
     val literal: String? = null,
-    val complex: MutableList<QueryFragment>? = null,
+    val complex: List<QueryFragment>? = null,
     val type: ComplexType? = null
 ) {
     companion object {
         fun createLiteral(
-            count: FragmentCount,
+            count: FragmentCount = FragmentCount.SINGLE,
             location: Location,
             literal: String
         ) = QueryFragment(count, location, literal)
 
         fun createComplex(
-            count: FragmentCount,
+            count: FragmentCount = FragmentCount.SINGLE,
             complex: Iterable<QueryFragment>,
             type: ComplexType = ComplexType.UNKNOWN
         ) = QueryFragment(
             count = count,
             location = Location.combine(complex.map { it.location }),
-            complex = complex.toMutableList(),
+            complex = complex.toList(),
             type = type
         )
 
         /**
-         * Combines [base] and [addition] into a complex fragment
-         * either by mutating [base] or by returning a newly created fragment
+         * Combines [left] and [right] into a complex fragment.
+         * If either fragments are null, a new fragment will not be constructed.
          */
         fun combine(
             count: FragmentCount,
-            base: QueryFragment,
-            addition: QueryFragment,
+            left: QueryFragment?,
+            right: QueryFragment?,
             type: ComplexType = ComplexType.UNKNOWN
-        ): QueryFragment {
-            return if (base.type != type || base.count != count) {
-                createComplex(count, listOf(base, addition), type)
-            } else {
-                base.location = Location.combine(base.location, addition.location)
-                base.complex!!.add(addition)
-                base
+        ): QueryFragment? {
+            if (left == null)
+                return right
+            if (right == null)
+                return left
+
+            val list = ArrayList<QueryFragment>()
+            for (fragment in sequenceOf(left, right)) {
+                if (fragment.type == type && fragment.count == count) {
+                    list.addAll(fragment.complex!!)
+                } else {
+                    list.add(fragment)
+                }
             }
+
+            return createComplex(count, list, type)
         }
     }
 }

--- a/tools/sql_extraction/src/test/kotlin/DataFlowSolverTest.kt
+++ b/tools/sql_extraction/src/test/kotlin/DataFlowSolverTest.kt
@@ -23,10 +23,9 @@ class DataFlowSolverTest {
         val filePath = mockk<Path>(relaxed = true)
         val stream = mockk<CharStream>(relaxed = true)
 
-        val frontEnd = mockk<FrontEnd>()
+        val frontEnd = mockk<FrontEnd>(relaxUnitFun = true)
         every { frontEnd.canSolve(any()) } returns true
         every { frontEnd.openFile(any()) } returns stream
-        every { frontEnd.solveDataFlow(any(), any()) } returns emptySequence()
 
         val solver = DataFlowSolver(listOf(frontEnd))
         solver.solveDataFlow(mockk(relaxed = true), filePath)
@@ -57,10 +56,9 @@ class DataFlowSolverTest {
         val invalidFrontEnd = mockk<FrontEnd>()
         every { invalidFrontEnd.canSolve(any()) } returns false
 
-        val frontEnd = mockk<FrontEnd>()
+        val frontEnd = mockk<FrontEnd>(relaxUnitFun = true)
         every { frontEnd.canSolve(any()) } returns true
         every { frontEnd.openFile(any()) } returns stream
-        every { frontEnd.solveDataFlow(any(), any()) } returns emptySequence()
 
         val solver = DataFlowSolver(listOf(invalidFrontEnd, frontEnd))
         solver.solveDataFlow(mockk(relaxed = true), filePath)

--- a/tools/sql_extraction/src/test/kotlin/FilesExpanderTest.kt
+++ b/tools/sql_extraction/src/test/kotlin/FilesExpanderTest.kt
@@ -7,8 +7,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-class FileListExpanderTest {
-    val expander = FileListExpander()
+class FilesExpanderTest {
+    val expander = FilesExpander()
 
     @Test
     fun `all files are included`() {
@@ -20,7 +20,7 @@ class FileListExpanderTest {
 
         val result = expander.expandAndFilter(listOf(fileA, fileB), false)
 
-        assertEquals(setOf(fileA, fileB), result)
+        assertEquals(setOf(fileA, fileB), result.toSet())
     }
 
     @Test
@@ -34,7 +34,7 @@ class FileListExpanderTest {
 
         val result = expander.expandAndFilter(listOf(fs.getPath("/dir")), false)
 
-        assertEquals(setOf(fileA, fileB), result)
+        assertEquals(setOf(fileA, fileB), result.toSet())
     }
 
     @Test
@@ -49,7 +49,7 @@ class FileListExpanderTest {
 
         val result = expander.expandAndFilter(listOf(fs.getPath("/dir")), false)
 
-        assertEquals(setOf(fileA), result)
+        assertEquals(setOf(fileA), result.toSet())
     }
 
     @Test
@@ -64,7 +64,7 @@ class FileListExpanderTest {
 
         val result = expander.expandAndFilter(listOf(fs.getPath("/dir")), true)
 
-        assertEquals(setOf(fileA, fileB), result)
+        assertEquals(setOf(fileA, fileB), result.toSet())
     }
 
     @Test
@@ -75,7 +75,7 @@ class FileListExpanderTest {
 
         val result = expander.expandAndFilter(listOf(fileA, fileA), false)
 
-        assertTrue(result.size == 1)
+        assertTrue(result.count() == 1)
     }
 
     @Test
@@ -86,9 +86,12 @@ class FileListExpanderTest {
         Files.createFile(fileA)
         Files.createFile(fileB)
 
-        val result = expander.expandAndFilter(listOf(fs.getPath("/")), false, includes = listOf("*.java"))
+        val result = expander.expandAndFilter(
+            listOf(fs.getPath("/")), false,
+            includes = listOf("*.java")
+        )
 
-        assertEquals(setOf(fileA), result)
+        assertEquals(setOf(fileA), result.toSet())
     }
 
     @Test
@@ -102,9 +105,12 @@ class FileListExpanderTest {
         Files.createFile(fileC)
 
         val result =
-            expander.expandAndFilter(listOf(fs.getPath("/")), false, includes = listOf("*.java", "*.maybejava"))
+            expander.expandAndFilter(
+                listOf(fs.getPath("/")), false,
+                includes = listOf("*.java", "*.maybejava")
+            )
 
-        assertEquals(setOf(fileA, fileB), result)
+        assertEquals(setOf(fileA, fileB), result.toSet())
     }
 
     @Test
@@ -115,9 +121,10 @@ class FileListExpanderTest {
         Files.createFile(fileA)
         Files.createFile(fileB)
 
-        val result = expander.expandAndFilter(listOf(fs.getPath("/")), false, excludes = listOf("*.notjava"))
+        val result =
+            expander.expandAndFilter(listOf(fs.getPath("/")), false, excludes = listOf("*.notjava"))
 
-        assertEquals(setOf(fileA), result)
+        assertEquals(setOf(fileA), result.toSet())
     }
 
     @Test
@@ -131,9 +138,12 @@ class FileListExpanderTest {
         Files.createFile(fileC)
 
         val result =
-            expander.expandAndFilter(listOf(fs.getPath("/")), false, excludes = listOf("*.notjava", "*.maybejava"))
+            expander.expandAndFilter(
+                listOf(fs.getPath("/")), false,
+                excludes = listOf("*.notjava", "*.maybejava")
+            )
 
-        assertEquals(setOf(fileA), result)
+        assertEquals(setOf(fileA), result.toSet())
     }
 
     @Test
@@ -153,7 +163,7 @@ class FileListExpanderTest {
             excludes = listOf("2.*")
         )
 
-        assertEquals(setOf(fileA), result)
+        assertEquals(setOf(fileA), result.toSet())
     }
 
     @Test
@@ -170,8 +180,11 @@ class FileListExpanderTest {
         Files.createFile(fileC)
         Files.createFile(fileD)
 
-        val result = expander.expandAndFilter(listOf(fs.getPath("/")), true, includes = listOf("*.java"))
+        val result = expander.expandAndFilter(
+            listOf(fs.getPath("/")), true,
+            includes = listOf("*.java")
+        )
 
-        assertEquals(setOf(fileA, fileB), result)
+        assertEquals(setOf(fileA, fileB), result.toSet())
     }
 }

--- a/tools/sql_extraction/src/test/kotlin/SqlExtractorTest.kt
+++ b/tools/sql_extraction/src/test/kotlin/SqlExtractorTest.kt
@@ -14,7 +14,7 @@ class SqlExtractorTest {
         val solver = mockk<DataFlowSolver>()
         every { solver.solveDataFlow(any(), any()) } returns emptySequence()
 
-        SqlExtractor(solver).process(listOf(mockk(relaxed = true)))
+        SqlExtractor(solver).process(sequenceOf(mockk(relaxed = true)))
         verify { solver.solveDataFlow(any(), any()) }
 
         confirmVerified()
@@ -25,9 +25,13 @@ class SqlExtractorTest {
         val solver = mockk<DataFlowSolver>()
         every { solver.solveDataFlow(any(), any()) } returns emptySequence()
 
-        val filePaths = listOf<Path>(mockk(relaxed = true), mockk(relaxed = true), mockk(relaxed = true))
+        val filePaths = listOf<Path>(
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true)
+        )
 
-        SqlExtractor(solver).process(filePaths)
+        SqlExtractor(solver).process(filePaths.asSequence())
         verifyAll { filePaths.map { solver.solveDataFlow(any(), it) } }
 
         confirmVerified()


### PR DESCRIPTION
I did some refactoring on the SQL Extraction project

- fixed minor mistake in readme (run -> build)
- made relevant classes input/output sequences (like Java streams but in Kotlin) instead of some other data structure
- made DataFlowSolver retrieve the queries from the engine rather than the frontend
- renamed FileListExpander to FilesExpander
- made QueryFragment immutable
- implemented Comparable for Location