### PR TITLE
Auto Query Fixer: Refactor the build and main class for frontend

### DIFF
--- a/tools/automatic_query_fixer/build.gradle
+++ b/tools/automatic_query_fixer/build.gradle
@@ -9,7 +9,7 @@ version '1.0-SNAPSHOT'
 
 
 application {
-    mainClassName = "com.google.cloud.bigquery.utils.auto_query_fixer.Application"
+    mainClassName = "com.google.cloud.bigquery.utils.queryfixer.QueryFixerMain"
 }
 
 repositories {

--- a/tools/automatic_query_fixer/src/main/java/com/google/cloud/bigquery/utils/queryfixer/QueryFixerMain.java
+++ b/tools/automatic_query_fixer/src/main/java/com/google/cloud/bigquery/utils/queryfixer/QueryFixerMain.java
@@ -101,8 +101,6 @@ public class QueryFixerMain {
     }
 
     String query = cmd.getArgList().get(0);
-    System.out.println("Input query: " + query);
-
     AutomaticQueryFixer queryFixer = new AutomaticQueryFixer(bigQueryOptions);
 
     String mode = cmd.getOptionValue(MODE);
@@ -128,7 +126,7 @@ public class QueryFixerMain {
       case FIX_ONCE_MODE:
       case FO_MODE:
         fixResult = fixQueryInFullInteractMode(queryFixer, query);
-        printFixResult(fixResult, cmd.getOptionValue(OUTPUT));
+        printFixResult(query, fixResult, cmd.getOptionValue(OUTPUT));
         break;
 
       default:
@@ -153,8 +151,9 @@ public class QueryFixerMain {
     return queryFixer.fix(query);
   }
 
-  private static void printFixResult(FixResult fixResult, String outputFormat) {
+  private static void printFixResult(String query, FixResult fixResult, String outputFormat) {
     if (outputFormat == null || outputFormat.equalsIgnoreCase(NATURAL_OUTPUT)) {
+      System.out.println("Input query: " + query);
       printFixResultInCommandLine(fixResult);
     } else if (outputFormat.equalsIgnoreCase(JSON_OUTPUT)) {
       printFixResultAsJson(fixResult);


### PR DESCRIPTION
Modify the build to fit in frontend.
Move the print of input query to natural-language output only.