### PR TITLE
VSCode Auto Fixer: display error highlights and code fixes

### DIFF
--- a/tools/vscode_automatic_query_fixer/.gitignore
+++ b/tools/vscode_automatic_query_fixer/.gitignore
@@ -2,5 +2,5 @@ out
 node_modules
 .vscode-test/
 *.vsix
-/resources/sql_extraction
+/resources/automatic_query_fixer
 !/.vscode/

--- a/tools/vscode_automatic_query_fixer/copy_binaries.js
+++ b/tools/vscode_automatic_query_fixer/copy_binaries.js
@@ -1,0 +1,36 @@
+const {spawn} = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const rimraf = require('rimraf');
+
+const projectDir = '../automatic_query_fixer/';
+const destinationDir = './resources/automatic_query_fixer';
+
+// launch gradle build
+let jarBuild;
+if (process.platform === 'win32') {
+  const batchScript = path.resolve(path.join(projectDir, 'gradlew.bat'));
+  jarBuild = spawn(batchScript, ['installDist'], {
+    cwd: projectDir,
+  });
+} else {
+  jarBuild = spawn('sh', ['gradlew', 'installDist'], {
+    cwd: projectDir,
+  });
+}
+jarBuild.stdout.pipe(process.stdout);
+jarBuild.stderr.pipe(process.stderr);
+jarBuild.on('close', code => {
+  if (code === 0) {
+    // delete previous copy
+    if (fs.existsSync(destinationDir)) {
+      rimraf.sync(destinationDir);
+    }
+    // move binaries to resources folder
+    fs.renameSync(
+      path.join(projectDir, 'build/install/AutomaticQueryFixer'),
+      destinationDir
+    );
+    console.log('\nAuto Fixer binaries updated successfully!');
+  }
+});

--- a/tools/vscode_automatic_query_fixer/package-lock.json
+++ b/tools/vscode_automatic_query_fixer/package-lock.json
@@ -299,8 +299,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "binary-extensions": {
       "version": "2.1.0",
@@ -380,7 +379,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -570,8 +568,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "configstore": {
       "version": "5.0.1",
@@ -1147,6 +1144,17 @@
         "flatted": "^2.0.0",
         "rimraf": "2.6.3",
         "write": "1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flatted": {
@@ -1158,8 +1166,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.1.3",
@@ -1205,7 +1212,6 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1577,7 +1583,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1586,8 +1591,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.5",
@@ -2037,7 +2041,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -2299,7 +2302,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -2413,8 +2415,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "2.0.1",
@@ -2675,10 +2676,9 @@
       }
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "dev": true,
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "requires": {
         "glob": "^7.1.3"
       }
@@ -3155,6 +3155,17 @@
         "http-proxy-agent": "^2.1.0",
         "https-proxy-agent": "^2.2.4",
         "rimraf": "^2.6.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "which": {
@@ -3268,8 +3279,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",

--- a/tools/vscode_automatic_query_fixer/package.json
+++ b/tools/vscode_automatic_query_fixer/package.json
@@ -17,20 +17,20 @@
     "Other"
   ],
   "activationEvents": [
-    "onCommand:vscode-automatic-query-fixer.helloWorld"
+    "onCommand:vscode-automatic-query-fixer.runAutoFixer"
   ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
       {
-        "command": "vscode-automatic-query-fixer.helloWorld",
-        "title": "Hello World"
+        "command": "vscode-automatic-query-fixer.runAutoFixer",
+        "title": "Analyze with Automatic Query Fixer"
       }
     ]
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
-    "compile": "tsc -p ./",
+    "compile": "tsc -p ./ && node ./copy_binaries.js",
     "lint": "eslint src --ext ts",
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile",
@@ -54,5 +54,8 @@
     "typescript": "^3.8.3",
     "gts": "^2.0.2",
     "vscode-test": "^1.3.0"
+  },
+  "dependencies": {
+    "rimraf": "^3.0.2"
   }
 }

--- a/tools/vscode_automatic_query_fixer/resources/MockAutoFixer
+++ b/tools/vscode_automatic_query_fixer/resources/MockAutoFixer
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+cat << EOF
+[
+  {
+    "status": "ERROR_FIXED",
+    "options": [
+      {
+        "description": "unique_key",
+        "fixedQuery": "SELECT unique_key FROM \`bigquery-public-data.austin_incidents.incidents_2008\` LIMIT 10"
+      }
+    ],
+    "error": "Unrecognized name: unique_keyx; Did you mean unique_key? at [1:8]",
+    "approach": "Replace the column",
+    "errorPosition": {
+      "row": 1,
+      "column": 8
+    }
+  }
+]
+EOF

--- a/tools/vscode_automatic_query_fixer/src/auto_fixer_result.ts
+++ b/tools/vscode_automatic_query_fixer/src/auto_fixer_result.ts
@@ -1,0 +1,17 @@
+export interface QueryFix {
+  status: string;
+  error?: string;
+  approach?: string;
+  errorPosition?: ErrorPosition;
+  options?: FixOption[];
+}
+
+export interface ErrorPosition {
+  row: number;
+  column: number;
+}
+
+export interface FixOption {
+  description: string;
+  fixedQuery: string;
+}

--- a/tools/vscode_automatic_query_fixer/src/auto_fixer_runner.ts
+++ b/tools/vscode_automatic_query_fixer/src/auto_fixer_runner.ts
@@ -1,0 +1,95 @@
+import {Progress, CancellationToken} from 'vscode';
+import {execFile} from 'child_process';
+import {QueryFix} from './auto_fixer_result';
+
+/**
+ * Runs an executable file provided by the Auto Fixer distribution.
+ */
+export class AutoFixerRunner {
+  constructor(private execPath: string) {}
+
+  /**
+   * execute Auto Fixer to analyze [query].
+   */
+  public analyze(
+    query: string,
+    progress: Progress<{
+      message?: string | undefined;
+      increment?: number | undefined;
+    }>,
+    token: CancellationToken
+  ): Promise<QueryFix[]> {
+    return this.execute(
+      ['-m', 'fo', '-o', 'json', '-p', 'sql-gravity-internship', query],
+      progress,
+      token
+    );
+  }
+
+  private execute(
+    args: string[],
+    progress: Progress<{
+      message?: string | undefined;
+      increment?: number | undefined;
+    }>,
+    token: CancellationToken
+  ): Promise<QueryFix[]> {
+    if (token.isCancellationRequested) {
+      return Promise.reject();
+    }
+
+    return new Promise<QueryFix[]>((resolve, reject) => {
+      progress.report({message: 'Launching Automatic Query Fixer...'});
+
+      let json = '';
+      let errMsg = '';
+      let totalProgress = 0;
+      const process = execFile(this.execPath, args)
+        .on('close', code => {
+          if (!process.killed && code === 0) {
+            let fixes = JSON.parse(json);
+            if (!Array.isArray(fixes)) {
+              // treat all output payload as an array
+              fixes = [fixes];
+            }
+            resolve(fixes);
+          } else {
+            reject();
+          }
+        })
+        .on('error', err => reject(err));
+
+      process.stdout!.on('data', data => {
+        json += data;
+      });
+      process.stderr!.on('data', data => {
+        errMsg += data;
+        const lines = errMsg.split('\n');
+        // if at least one entire message was received completely up to newline
+        if (lines.length > 1) {
+          for (let i = 0; i < lines.length - 2; i++) {
+            const statement = lines[i];
+
+            // if the error message starts with a percentage
+            if (statement.match(/^\d+(\.\d*)?% .*$/)) {
+              const percent = parseFloat(statement);
+              const nextTotalProgress = isNaN(percent)
+                ? totalProgress
+                : percent;
+              const message = statement.substring(statement.indexOf('%' + 2));
+              progress.report({
+                message: message,
+                increment: nextTotalProgress - totalProgress,
+              });
+              totalProgress = nextTotalProgress;
+            }
+          }
+          // save the remainder for later
+          // this works even if '\n' appears at the very end
+          errMsg = lines[lines.length - 1];
+        }
+      });
+      token.onCancellationRequested(() => process.kill());
+    });
+  }
+}

--- a/tools/vscode_automatic_query_fixer/src/code_action_provider.ts
+++ b/tools/vscode_automatic_query_fixer/src/code_action_provider.ts
@@ -1,0 +1,114 @@
+import * as vscode from 'vscode';
+import {QueryFix} from './auto_fixer_result';
+
+/**
+ * Provides error highlights and code fixes for the currently open document.
+ */
+export class AutoFixerActionProvider implements vscode.CodeActionProvider {
+  private fixes?: QueryFix[];
+  private uri?: vscode.Uri;
+  /** Location of scanned query. Currently, it's the entire document. */
+  private range?: vscode.Range;
+
+  constructor(
+    private readonly diagnosticCollection: vscode.DiagnosticCollection
+  ) {}
+
+  /**
+   * Initializes the errors to show on [openEditor] and any potential fixes.
+   */
+  setFixes(fixes: QueryFix[], openEditor: vscode.TextEditor) {
+    let hasErrors = false;
+
+    const diagnostics: vscode.Diagnostic[] = [];
+    fixes.forEach(fix => {
+      if (!fix.error || !fix.errorPosition) {
+        return;
+      }
+      hasErrors = true;
+
+      let msg = fix.error!;
+      if (fix.approach) {
+        msg += ' ' + fix.approach!;
+      }
+
+      // highlight the immediate token
+      const range = openEditor.document.getWordRangeAtPosition(
+        new vscode.Position(
+          fix.errorPosition.row - 1,
+          fix.errorPosition.column - 1
+        )
+      )!;
+
+      diagnostics.push(
+        new vscode.Diagnostic(range, msg, vscode.DiagnosticSeverity.Error)
+      );
+    });
+
+    if (!hasErrors) {
+      vscode.window.showInformationMessage('No errors were found.');
+    }
+
+    this.diagnosticCollection.set(openEditor.document.uri, diagnostics);
+
+    this.fixes = fixes;
+    this.uri = openEditor.document.uri;
+    // set range to entire document text
+    this.range = openEditor.document.validateRange(
+      new vscode.Range(0, 0, openEditor.document.lineCount, 0)
+    );
+  }
+
+  /**
+   * Clears all error highlights.
+   */
+  clear() {
+    this.fixes = undefined;
+    this.uri = undefined;
+    this.range = undefined;
+    this.diagnosticCollection.clear();
+  }
+
+  /**
+   * Called by the API to potentially provide code fixes for the given [document] and [range].
+   */
+  provideCodeActions(
+    document: vscode.TextDocument,
+    range: vscode.Range | vscode.Selection
+  ): vscode.ProviderResult<(vscode.Command | vscode.CodeAction)[]> {
+    if (!this.fixes || document.uri !== this.uri) {
+      return [];
+    }
+
+    return this.fixes
+      .filter(
+        fix =>
+          // for all errors contained in the given range with code fixes
+          fix.options &&
+          fix.errorPosition &&
+          range.contains(
+            new vscode.Position(
+              fix.errorPosition.row - 1,
+              fix.errorPosition.column - 1
+            )
+          )
+      )
+      .map(fix =>
+        // create an action to replace the query with the fix
+        fix.options!.map(option => {
+          const workspaceEdit = new vscode.WorkspaceEdit();
+          workspaceEdit.replace(this.uri!, this.range!, option.fixedQuery);
+          const action = new vscode.CodeAction(
+            `${option.description}. Replace query with ${option.fixedQuery}`,
+            vscode.CodeActionKind.QuickFix
+          );
+          action.diagnostics = this.diagnosticCollection
+            .get(this.uri!)!
+            .slice();
+          action.edit = workspaceEdit;
+          return action;
+        })
+      )
+      .reduce((acc, val) => acc.concat(val)); // flatten map
+  }
+}


### PR DESCRIPTION
The copy_binaries and auto_fixer_runner were copied over from the SQL Extraction VS Code extension. I could invest in a way to combine them later. Additionally, the auto_fixer_results are simply for the JSON format definition.

The extension should now be fully integrated with @mingen-pan's Auto Fixer.