### PR TITLE
Auto Query Fixer: Implement ExtractFunctionRange, LocateTableRanges, GetAllKeywords methods in ZetaSQL Helper server

### DIFF
--- a/tools/zetasql_helper/zetasql_helper/local_service/BUILD
+++ b/tools/zetasql_helper/zetasql_helper/local_service/BUILD
@@ -9,7 +9,9 @@ proto_library(
     name = "local_service_proto",
     srcs = ["local_service.proto"],
     deps = [
-        "//zetasql_helper/token:parse_token_proto"
+        "//zetasql_helper/token:parse_token_proto",
+        "//zetasql_helper/scanner:function_range_proto",
+        "@com_google_zetasql//zetasql/public:parse_location_range_proto",
     ],
 )
 
@@ -34,6 +36,8 @@ cc_library(
         ":local_service_cc_proto",
         # dep regarding implementation
         "//zetasql_helper/token",
+        "//zetasql_helper/scanner:locate_table",
+        "//zetasql_helper/scanner:extract_function",
         "@com_google_zetasql//zetasql/parser",
     ],
 )

--- a/tools/zetasql_helper/zetasql_helper/local_service/local_service.cc
+++ b/tools/zetasql_helper/zetasql_helper/local_service/local_service.cc
@@ -23,27 +23,27 @@
 namespace bigquery::utils::zetasql_helper::local_service {
 
 absl::Status ZetaSqlHelperLocalServiceImpl::Tokenize(
-    const TokenizeRequest *request,
+    const TokenizeRequest& request,
     TokenizeResponse *response) {
 
   std::vector<zetasql::ParseToken> tokens;
-  ZETASQL_RETURN_IF_ERROR(::bigquery::utils::zetasql_helper::Tokenize(request->query(), tokens));
+  ZETASQL_RETURN_IF_ERROR(::bigquery::utils::zetasql_helper::Tokenize(request.query(), tokens));
 
   for (auto &token : tokens) {
     auto token_proto = ::bigquery::utils::zetasql_helper::serialize_token(token);
-    response->add_parse_token()->CopyFrom(token_proto);
+    response->add_parse_tokens()->CopyFrom(token_proto);
   }
   return absl::OkStatus();
 }
 
 absl::Status ZetaSqlHelperLocalServiceImpl::ExtractFunctionRange(
-    const ExtractFunctionRangeRequest *request,
+    const ExtractFunctionRangeRequest& request,
     ExtractFunctionRangeResponse *response) {
 
   std::unique_ptr<::bigquery::utils::zetasql_helper::FunctionRange> output;
   ZETASQL_RETURN_IF_ERROR(
       ::bigquery::utils::zetasql_helper::ExtractFunctionRange(
-          request->query(), request->line_number(), request->column_number(), &output
+          request.query(), request.line_number(), request.column_number(), &output
       ));
 
   auto status_or_function_range_proto = output->ToProto();
@@ -57,25 +57,24 @@ absl::Status ZetaSqlHelperLocalServiceImpl::ExtractFunctionRange(
   return absl::OkStatus();
 }
 
-absl::Status ZetaSqlHelperLocalServiceImpl::LocateTableRanges(const LocateTableRangesRequest *request,
-                                                              LocateTableRangesResponse *response) {
+absl::Status ZetaSqlHelperLocalServiceImpl::LocateTableRanges(const LocateTableRangesRequest& request,
+                                                              LocateTableRangesResponse* response) {
   std::vector<zetasql::ParseLocationRange> ranges;
   ZETASQL_RETURN_IF_ERROR(
-      ::bigquery::utils::zetasql_helper::LocateTableRanges(request->query(), request->table_regex(), ranges)
+      ::bigquery::utils::zetasql_helper::LocateTableRanges(request.query(), request.table_regex(), ranges)
   );
-  for (auto &range : ranges) {
-    auto status_or_value = range.ToProto();
-    ZETASQL_RETURN_IF_ERROR(status_or_value.status());
-    response->add_table_ranges()->CopyFrom(status_or_value.value());
+  for (const auto& range : ranges) {
+    ZETASQL_ASSIGN_OR_RETURN(auto value, range.ToProto());
+    response->add_table_ranges()->CopyFrom(value);
   }
 
   return absl::Status();
 }
 
-absl::Status ZetaSqlHelperLocalServiceImpl::GetAllKeywords(const AllKeywordsRequest *request,
-                                                           AllKeywordsResponse *response) {
+absl::Status ZetaSqlHelperLocalServiceImpl::GetAllKeywords(const GetAllKeywordsRequest& request,
+                                                           GetAllKeywordsResponse *response) {
   auto keywordInfos = zetasql::parser::GetAllKeywords();
-  for (auto &keywordInfo : keywordInfos) {
+  for (const auto& keywordInfo : keywordInfos) {
     response->add_keywords(keywordInfo.keyword());
   }
 

--- a/tools/zetasql_helper/zetasql_helper/local_service/local_service.cc
+++ b/tools/zetasql_helper/zetasql_helper/local_service/local_service.cc
@@ -16,6 +16,9 @@
 
 #include "local_service.h"
 #include "zetasql_helper/token/token.h"
+#include "zetasql_helper/scanner/extract_function.h"
+#include "zetasql/parser/keywords.h"
+#include "zetasql_helper/scanner/locate_table.h"
 
 namespace bigquery::utils::zetasql_helper::local_service {
 
@@ -31,6 +34,52 @@ absl::Status ZetaSqlHelperLocalServiceImpl::Tokenize(
     response->add_parse_token()->CopyFrom(token_proto);
   }
   return absl::OkStatus();
+}
+
+absl::Status ZetaSqlHelperLocalServiceImpl::ExtractFunctionRange(
+    const ExtractFunctionRangeRequest *request,
+    ExtractFunctionRangeResponse *response) {
+
+  std::unique_ptr<::bigquery::utils::zetasql_helper::FunctionRange> output;
+  ZETASQL_RETURN_IF_ERROR(
+      ::bigquery::utils::zetasql_helper::ExtractFunctionRange(
+          request->query(), request->line_number(), request->column_number(), &output
+      ));
+
+  auto status_or_function_range_proto = output->ToProto();
+  ZETASQL_RETURN_IF_ERROR(status_or_function_range_proto.status());
+
+  // Convert the proto to heap value and hand over the ownership to the response.
+  auto function_range_proto = new ::bigquery::utils::zetasql_helper::FunctionRangeProto(
+      status_or_function_range_proto.value()
+  );
+  response->set_allocated_function_range(function_range_proto);
+  return absl::OkStatus();
+}
+
+absl::Status ZetaSqlHelperLocalServiceImpl::LocateTableRanges(const LocateTableRangesRequest *request,
+                                                              LocateTableRangesResponse *response) {
+  std::vector<zetasql::ParseLocationRange> ranges;
+  ZETASQL_RETURN_IF_ERROR(
+      ::bigquery::utils::zetasql_helper::LocateTableRanges(request->query(), request->table_regex(), ranges)
+  );
+  for (auto &range : ranges) {
+    auto status_or_value = range.ToProto();
+    ZETASQL_RETURN_IF_ERROR(status_or_value.status());
+    response->add_table_ranges()->CopyFrom(status_or_value.value());
+  }
+
+  return absl::Status();
+}
+
+absl::Status ZetaSqlHelperLocalServiceImpl::GetAllKeywords(const AllKeywordsRequest *request,
+                                                           AllKeywordsResponse *response) {
+  auto keywordInfos = zetasql::parser::GetAllKeywords();
+  for (auto &keywordInfo : keywordInfos) {
+    response->add_keywords(keywordInfo.keyword());
+  }
+
+  return absl::Status();
 }
 
 }//bigquery::utils::zetasql_helper::local_service

--- a/tools/zetasql_helper/zetasql_helper/local_service/local_service.h
+++ b/tools/zetasql_helper/zetasql_helper/local_service/local_service.h
@@ -30,6 +30,15 @@ class ZetaSqlHelperLocalServiceImpl {
   absl::Status Tokenize(const TokenizeRequest *req,
                         TokenizeResponse *resp);
 
+  absl::Status ExtractFunctionRange(const ExtractFunctionRangeRequest *request,
+                                    ExtractFunctionRangeResponse *response);
+
+  absl::Status LocateTableRanges(const LocateTableRangesRequest *request,
+                                 LocateTableRangesResponse *response);
+
+  absl::Status GetAllKeywords(const AllKeywordsRequest *request,
+                              AllKeywordsResponse *response);
+
   ZetaSqlHelperLocalServiceImpl() = default;
 };
 

--- a/tools/zetasql_helper/zetasql_helper/local_service/local_service.h
+++ b/tools/zetasql_helper/zetasql_helper/local_service/local_service.h
@@ -27,17 +27,17 @@ class ZetaSqlHelperLocalServiceImpl {
   ZetaSqlHelperLocalServiceImpl(const ZetaSqlHelperLocalServiceImpl &) = delete;
   ZetaSqlHelperLocalServiceImpl &operator=(const ZetaSqlHelperLocalServiceImpl &) = delete;
 
-  absl::Status Tokenize(const TokenizeRequest *req,
-                        TokenizeResponse *resp);
+  absl::Status Tokenize(const TokenizeRequest& req,
+                        TokenizeResponse* resp);
 
-  absl::Status ExtractFunctionRange(const ExtractFunctionRangeRequest *request,
-                                    ExtractFunctionRangeResponse *response);
+  absl::Status ExtractFunctionRange(const ExtractFunctionRangeRequest& request,
+                                    ExtractFunctionRangeResponse* response);
 
-  absl::Status LocateTableRanges(const LocateTableRangesRequest *request,
-                                 LocateTableRangesResponse *response);
+  absl::Status LocateTableRanges(const LocateTableRangesRequest& request,
+                                 LocateTableRangesResponse* response);
 
-  absl::Status GetAllKeywords(const AllKeywordsRequest *request,
-                              AllKeywordsResponse *response);
+  absl::Status GetAllKeywords(const GetAllKeywordsRequest&request,
+                              GetAllKeywordsResponse* response);
 
   ZetaSqlHelperLocalServiceImpl() = default;
 };

--- a/tools/zetasql_helper/zetasql_helper/local_service/local_service.proto
+++ b/tools/zetasql_helper/zetasql_helper/local_service/local_service.proto
@@ -36,7 +36,7 @@ service ZetaSqlHelperLocalService {
   rpc LocateTableRanges(LocateTableRangesRequest) returns (LocateTableRangesResponse) {
   }
 
-  rpc AllKeywords(AllKeywordsRequest) returns (AllKeywordsResponse) {
+  rpc GetAllKeywords(GetAllKeywordsRequest) returns (GetAllKeywordsResponse) {
   }
 
 }
@@ -46,12 +46,43 @@ message TokenizeRequest {
 }
 
 message TokenizeResponse {
-  repeated ParseTokenProto parse_token = 1;
+  repeated ParseTokenProto parse_tokens = 1;
+}
+
+message FixColumnNotGroupedRequest {
+  // The input query with "Column Not Grouped" error
+  optional string query = 1;
+  // Name of the missing column in the GROUP BY clause
+  optional string missing_column = 2;
+  // line number of the error
+  optional int32 line_number = 3;
+  // column number of the error
+  optional int32 column_number = 4;
+
+}
+
+message FixColumnNotGroupedResponse {
+  optional string fixed_query = 1;
+}
+
+message FixDuplicateColumnsRequest {
+  // The input query with "Duplicate Columns" error
+  optional string query = 1;
+  // Name of the duplicate columns
+  optional string duplicate_column = 2;
+
+}
+
+message FixDuplicateColumnsResponse {
+  optional string fixed_query = 1;
 }
 
 message ExtractFunctionRangeRequest {
+  // Query to extract the function range
   optional string query = 1;
+  // Line number of the function starting point
   optional int32 line_number = 2;
+  // Column number of the function starting point
   optional int32 column_number = 3;
 
 }
@@ -61,7 +92,9 @@ message ExtractFunctionRangeResponse {
 }
 
 message LocateTableRangesRequest {
+  // Query to locate the tables meeting a regex
   optional string query = 1;
+  // Regex to match table names
   optional string table_regex = 2;
 
 }
@@ -70,10 +103,9 @@ message LocateTableRangesResponse {
   repeated zetasql.ParseLocationRangeProto table_ranges = 1;
 }
 
-message AllKeywordsRequest {
-
+message GetAllKeywordsRequest {
 }
 
-message AllKeywordsResponse {
+message GetAllKeywordsResponse {
   repeated string keywords = 1;
 }

--- a/tools/zetasql_helper/zetasql_helper/local_service/local_service.proto
+++ b/tools/zetasql_helper/zetasql_helper/local_service/local_service.proto
@@ -18,7 +18,9 @@ syntax = "proto2";
 
 package bigquery.utils.zetasql_helper.local_service;
 
+import "zetasql/public/parse_location_range.proto";
 import "zetasql_helper/token/parse_token.proto";
+import "zetasql_helper/scanner/function_range.proto";
 
 option java_package = "com.google.bigquery.utils.zetasqlhelper";
 option java_outer_classname = "LocalService";
@@ -26,6 +28,15 @@ option java_outer_classname = "LocalService";
 service ZetaSqlHelperLocalService {
 
   rpc Tokenize(TokenizeRequest) returns (TokenizeResponse) {
+  }
+
+  rpc ExtractFunctionRange(ExtractFunctionRangeRequest) returns (ExtractFunctionRangeResponse) {
+  }
+
+  rpc LocateTableRanges(LocateTableRangesRequest) returns (LocateTableRangesResponse) {
+  }
+
+  rpc AllKeywords(AllKeywordsRequest) returns (AllKeywordsResponse) {
   }
 
 }
@@ -36,4 +47,33 @@ message TokenizeRequest {
 
 message TokenizeResponse {
   repeated ParseTokenProto parse_token = 1;
+}
+
+message ExtractFunctionRangeRequest {
+  optional string query = 1;
+  optional int32 line_number = 2;
+  optional int32 column_number = 3;
+
+}
+
+message ExtractFunctionRangeResponse {
+  optional FunctionRangeProto function_range = 1;
+}
+
+message LocateTableRangesRequest {
+  optional string query = 1;
+  optional string table_regex = 2;
+
+}
+
+message LocateTableRangesResponse {
+  repeated zetasql.ParseLocationRangeProto table_ranges = 1;
+}
+
+message AllKeywordsRequest {
+
+}
+
+message AllKeywordsResponse {
+  repeated string keywords = 1;
 }

--- a/tools/zetasql_helper/zetasql_helper/local_service/local_service_grpc.cc
+++ b/tools/zetasql_helper/zetasql_helper/local_service/local_service_grpc.cc
@@ -70,5 +70,24 @@ grpc::Status ZetaSqlHelperLocalServiceGrpcImpl::Tokenize(grpc::ServerContext *co
   return ToGrpcStatus(service_.Tokenize(request, response));
 }
 
+grpc::Status ZetaSqlHelperLocalServiceGrpcImpl::ExtractFunctionRange(grpc::ServerContext *context,
+                                                                     const ExtractFunctionRangeRequest *request,
+                                                                     ExtractFunctionRangeResponse *response) {
+  return ToGrpcStatus(service_.ExtractFunctionRange(request, response));
+}
+
+grpc::Status ZetaSqlHelperLocalServiceGrpcImpl::LocateTableRanges(grpc::ServerContext *context,
+                                                                  const LocateTableRangesRequest *request,
+                                                                  LocateTableRangesResponse *response) {
+
+  return ToGrpcStatus(service_.LocateTableRanges(request, response));
+}
+
+grpc::Status ZetaSqlHelperLocalServiceGrpcImpl::AllKeywords(grpc::ServerContext *context,
+                                                            const AllKeywordsRequest *request,
+                                                            AllKeywordsResponse *response) {
+
+  return ToGrpcStatus(service_.GetAllKeywords(request, response));
+}
 
 } // bigquery::utils::zetasql_helper::local_service

--- a/tools/zetasql_helper/zetasql_helper/local_service/local_service_grpc.cc
+++ b/tools/zetasql_helper/zetasql_helper/local_service/local_service_grpc.cc
@@ -65,29 +65,29 @@ grpc::Status ToGrpcStatus(absl::Status status) {
 namespace bigquery::utils::zetasql_helper::local_service {
 using namespace bigquery::utils::zetasql_helper;
 
-grpc::Status ZetaSqlHelperLocalServiceGrpcImpl::Tokenize(grpc::ServerContext *context, const TokenizeRequest *request,
-                                                         TokenizeResponse *response) {
-  return ToGrpcStatus(service_.Tokenize(request, response));
+grpc::Status ZetaSqlHelperLocalServiceGrpcImpl::Tokenize(grpc::ServerContext* context, const TokenizeRequest* request,
+                                                         TokenizeResponse* response) {
+  return ToGrpcStatus(service_.Tokenize(*request, response));
 }
 
-grpc::Status ZetaSqlHelperLocalServiceGrpcImpl::ExtractFunctionRange(grpc::ServerContext *context,
-                                                                     const ExtractFunctionRangeRequest *request,
-                                                                     ExtractFunctionRangeResponse *response) {
-  return ToGrpcStatus(service_.ExtractFunctionRange(request, response));
+grpc::Status ZetaSqlHelperLocalServiceGrpcImpl::ExtractFunctionRange(grpc::ServerContext* context,
+                                                                     const ExtractFunctionRangeRequest* request,
+                                                                     ExtractFunctionRangeResponse* response) {
+  return ToGrpcStatus(service_.ExtractFunctionRange(*request, response));
 }
 
-grpc::Status ZetaSqlHelperLocalServiceGrpcImpl::LocateTableRanges(grpc::ServerContext *context,
-                                                                  const LocateTableRangesRequest *request,
-                                                                  LocateTableRangesResponse *response) {
+grpc::Status ZetaSqlHelperLocalServiceGrpcImpl::LocateTableRanges(grpc::ServerContext* context,
+                                                                  const LocateTableRangesRequest* request,
+                                                                  LocateTableRangesResponse* response) {
 
-  return ToGrpcStatus(service_.LocateTableRanges(request, response));
+  return ToGrpcStatus(service_.LocateTableRanges(*request, response));
 }
 
-grpc::Status ZetaSqlHelperLocalServiceGrpcImpl::AllKeywords(grpc::ServerContext *context,
-                                                            const AllKeywordsRequest *request,
-                                                            AllKeywordsResponse *response) {
+grpc::Status ZetaSqlHelperLocalServiceGrpcImpl::GetAllKeywords(grpc::ServerContext* context,
+                                                            const GetAllKeywordsRequest* request,
+                                                            GetAllKeywordsResponse* response) {
 
-  return ToGrpcStatus(service_.GetAllKeywords(request, response));
+  return ToGrpcStatus(service_.GetAllKeywords(*request, response));
 }
 
 } // bigquery::utils::zetasql_helper::local_service

--- a/tools/zetasql_helper/zetasql_helper/local_service/local_service_grpc.h
+++ b/tools/zetasql_helper/zetasql_helper/local_service/local_service_grpc.h
@@ -30,6 +30,17 @@ class ZetaSqlHelperLocalServiceGrpcImpl : public ZetaSqlHelperLocalService::Serv
   grpc::Status Tokenize(grpc::ServerContext *context, const TokenizeRequest *req,
                         TokenizeResponse *resp) override;
 
+  grpc::Status ExtractFunctionRange(grpc::ServerContext *context, const ExtractFunctionRangeRequest *request,
+                                    ExtractFunctionRangeResponse *response) override;
+
+  grpc::Status LocateTableRanges(grpc::ServerContext *context,
+                                 const LocateTableRangesRequest *request,
+                                 LocateTableRangesResponse *response) override;
+
+  grpc::Status AllKeywords(grpc::ServerContext *context,
+                           const AllKeywordsRequest *request,
+                           AllKeywordsResponse *response) override;
+
  private:
   ZetaSqlHelperLocalServiceImpl service_;
 };

--- a/tools/zetasql_helper/zetasql_helper/local_service/local_service_grpc.h
+++ b/tools/zetasql_helper/zetasql_helper/local_service/local_service_grpc.h
@@ -27,19 +27,19 @@ namespace bigquery::utils::zetasql_helper::local_service {
 class ZetaSqlHelperLocalServiceGrpcImpl : public ZetaSqlHelperLocalService::Service {
  public:
 
-  grpc::Status Tokenize(grpc::ServerContext *context, const TokenizeRequest *req,
-                        TokenizeResponse *resp) override;
+  grpc::Status Tokenize(grpc::ServerContext* context, const TokenizeRequest* request,
+                        TokenizeResponse* response) override;
 
-  grpc::Status ExtractFunctionRange(grpc::ServerContext *context, const ExtractFunctionRangeRequest *request,
+  grpc::Status ExtractFunctionRange(grpc::ServerContext* context, const ExtractFunctionRangeRequest* request,
                                     ExtractFunctionRangeResponse *response) override;
 
-  grpc::Status LocateTableRanges(grpc::ServerContext *context,
-                                 const LocateTableRangesRequest *request,
-                                 LocateTableRangesResponse *response) override;
+  grpc::Status LocateTableRanges(grpc::ServerContext* context,
+                                 const LocateTableRangesRequest* request,
+                                 LocateTableRangesResponse* response) override;
 
-  grpc::Status AllKeywords(grpc::ServerContext *context,
-                           const AllKeywordsRequest *request,
-                           AllKeywordsResponse *response) override;
+  grpc::Status GetAllKeywords(grpc::ServerContext* context,
+                           const GetAllKeywordsRequest* request,
+                           GetAllKeywordsResponse* response) override;
 
  private:
   ZetaSqlHelperLocalServiceImpl service_;

--- a/tools/zetasql_helper/zetasql_helper/local_service/local_service_test.cc
+++ b/tools/zetasql_helper/zetasql_helper/local_service/local_service_test.cc
@@ -38,7 +38,7 @@ TEST_F(LocalServiceTest, TokenizeTest) {
   request.set_query(query);
   GetService().Tokenize(nullptr, &request, &response);
 
-  auto tokens = response.parse_token();
+  auto tokens = response.parse_tokens();
 
   EXPECT_EQ(4, tokens.size());
   EXPECT_EQ("select", tokens[0].image());
@@ -88,5 +88,13 @@ TEST_F(LocalServiceTest, LocateTableRangesTest) {
   EXPECT_EQ("`austin_311`.311_request", range_to_string(query, response.table_ranges()[1]));
 }
 
+
+TEST_F(LocalServiceTest, GetAllKeywords) {
+  GetAllKeywordsRequest request;
+  GetAllKeywordsResponse response;
+  GetService().GetAllKeywords(nullptr, &request, &response);
+
+  EXPECT_EQ(231, response.keywords().size());
+}
 }
 

--- a/tools/zetasql_helper/zetasql_helper/local_service/local_service_test.cc
+++ b/tools/zetasql_helper/zetasql_helper/local_service/local_service_test.cc
@@ -74,7 +74,7 @@ TEST_F(LocalServiceTest, ExtractFunctionRangeTest) {
 }
 
 TEST_F(LocalServiceTest, LocateTableRangesTest) {
-  std::string query = "SELECT `哈哈`, status FROM bigquery-public-data.`austin_311.311_request`"
+  std::string query = "SELECT `特殊字符 (unicode characters)`, status FROM bigquery-public-data.`austin_311.311_request`"
                       "cross join `austin_311`.311_request\n"
                       "where status = '`bigquery-public-data.austin_311.311_request`'";
   LocateTableRangesRequest request;

--- a/tools/zetasql_helper/zetasql_helper/scanner/BUILD
+++ b/tools/zetasql_helper/zetasql_helper/scanner/BUILD
@@ -1,0 +1,58 @@
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "extract_function",
+    srcs = ["extract_function.cc"],
+    hdrs = ["extract_function.h"],
+    deps = [
+        "@com_google_zetasql//zetasql/parser",
+        "@com_google_zetasql//zetasql/parser:parse_tree",
+        "@com_google_zetasql//zetasql/public:analyzer",
+        ":function_range_cc_proto",
+        "//zetasql_helper/util:util",
+    ],
+)
+
+cc_library(
+    name = "locate_table",
+    srcs = ["locate_table.cc"],
+    hdrs = ["locate_table.h"],
+    deps = [
+        "@com_google_zetasql//zetasql/parser",
+        "@com_google_zetasql//zetasql/parser:parse_tree",
+        "@com_google_zetasql//zetasql/public:analyzer",
+        "//zetasql_helper/util:util",
+    ],
+)
+
+proto_library(
+    name = "function_range_proto",
+    srcs = ["function_range.proto"],
+    deps = [
+        "@com_google_zetasql//zetasql/public:parse_location_range_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "function_range_cc_proto",
+    deps = [":function_range_proto"],
+)
+
+java_proto_library(
+    name = "function_range_java_proto",
+    deps = [":function_range_proto"],
+)
+
+cc_test(
+    name = "scanner_test",
+    size = "small",
+    srcs = ["scanner_test.cc"],
+    copts = ["-Wno-sign-compare"],
+    deps = [
+        ":locate_table",
+        ":extract_function",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/tools/zetasql_helper/zetasql_helper/scanner/extract_function.cc
+++ b/tools/zetasql_helper/zetasql_helper/scanner/extract_function.cc
@@ -1,0 +1,78 @@
+#include "extract_function.h"
+#include "zetasql/public/analyzer.h"
+#include "zetasql/parser/parser.h"
+#include "zetasql_helper/util/util.h"
+
+namespace bigquery::utils::zetasql_helper {
+
+FunctionRange::FunctionRange(const zetasql::ASTFunctionCall *function_call) {
+  function = function_call->GetParseLocationRange();
+  name = function_call->function()->GetParseLocationRange();
+  std::vector<zetasql::ParseLocationRange> ranges;
+  for (auto argument : function_call->arguments()) {
+    ranges.push_back(argument->GetParseLocationRange());
+  }
+  arguments = ranges;
+}
+
+zetasql_base::StatusOr<FunctionRangeProto> FunctionRange::ToProto() const {
+  FunctionRangeProto proto;
+  // location range transfer
+  auto status_or_function_proto = function.ToProto();
+  ZETASQL_RETURN_IF_ERROR(status_or_function_proto.status());
+
+  auto range_proto = new zetasql::ParseLocationRangeProto(status_or_function_proto.value());
+  proto.set_allocated_function(range_proto);
+
+  // name range transfer
+  auto status_or_name_proto = name.ToProto();
+  ZETASQL_RETURN_IF_ERROR(status_or_name_proto.status());
+
+  range_proto = new zetasql::ParseLocationRangeProto(status_or_name_proto.value());
+  proto.set_allocated_name(range_proto);
+
+  for (auto &argument_range : arguments) {
+
+    auto status_or_argument_proto = argument_range.ToProto();
+    ZETASQL_RETURN_IF_ERROR(status_or_argument_proto.status());
+    proto.add_arguments()->CopyFrom(status_or_argument_proto.value());
+  }
+
+  return proto;
+}
+
+
+absl::Status ExtractFunctionRange(absl::string_view query,
+                                  int row,
+                                  int column,
+                                  std::unique_ptr<FunctionRange> *output) {
+
+  std::unique_ptr<zetasql::ParserOutput> parser_output;
+  auto options = BigQueryOptions();
+  auto status = ParseStatement(query, options.GetParserOptions(), &parser_output);
+  if (!status.ok()) {
+    return status;
+  }
+
+  auto offset = get_offset(query, row, column);
+  auto predicator = [offset](const zetasql::ASTNode *node) {
+    return node->GetParseLocationRange().start().GetByteOffset() == offset &&
+        node->node_kind() == zetasql::ASTNodeKind::AST_FUNCTION_CALL;
+  };
+
+  auto candidate = find_node(parser_output->statement(), predicator);
+  if (candidate == nullptr) {
+    return absl::Status(absl::StatusCode::kInvalidArgument, "Line and/or column numbers are incorrect");
+  }
+
+  auto function_call = dynamic_cast<const zetasql::ASTFunctionCall *>(candidate);
+  if (function_call == nullptr) {
+    return absl::Status(absl::StatusCode::kInvalidArgument, "The provided position is not function node.");
+  }
+
+  *output = absl::make_unique<FunctionRange>(function_call);
+  return absl::OkStatus();
+}
+
+}
+

--- a/tools/zetasql_helper/zetasql_helper/scanner/extract_function.cc
+++ b/tools/zetasql_helper/zetasql_helper/scanner/extract_function.cc
@@ -1,3 +1,19 @@
+//
+// Copyright 2020 BigQuery Utils
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 #include "extract_function.h"
 #include "zetasql/public/analyzer.h"
 #include "zetasql/parser/parser.h"

--- a/tools/zetasql_helper/zetasql_helper/scanner/extract_function.h
+++ b/tools/zetasql_helper/zetasql_helper/scanner/extract_function.h
@@ -1,0 +1,45 @@
+//
+// Created by mepan on 8/22/20.
+//
+
+#ifndef ZETASQL_HELPER_ZETASQL_HELPER_FUNCTION_LOCATE_FUNCTION_H_
+#define ZETASQL_HELPER_ZETASQL_HELPER_FUNCTION_LOCATE_FUNCTION_H_
+
+#include "zetasql/public/parse_location.h"
+#include "zetasql/parser/parse_tree.h"
+#include "zetasql_helper/scanner/function_range.pb.h"
+
+namespace bigquery::utils::zetasql_helper {
+
+// A struct to store the range of different components of a function. It includes the range
+// of the whole function, the name, and each arguments.
+struct FunctionRange {
+  zetasql::ParseLocationRange function;
+  zetasql::ParseLocationRange name;
+  std::vector<zetasql::ParseLocationRange> arguments;
+
+  FunctionRange(const zetasql::ASTFunctionCall *function_call);
+
+  // Serialize the FunctionRange to its Protobuf object.
+  zetasql_base::StatusOr<FunctionRangeProto> ToProto() const;
+
+};
+
+// Extract the FunctionRange of a function beginning at the input row and column number.
+// Both row and column number are 1-based index. The extracted FunctionRange will be
+// assigned to the output unique pointer. If an error occurs, a status with the error
+// will be returned. Otherwise, a OKStatus will be returned.
+//
+// Extraction example:
+// foo.bar(123, foo.bar(1,2,3), "a") will be extracted as
+// function: foo.bar(123, foo.bar(1,2,3), "a")
+// name: foo.bar
+// arguments: [123, foo.bar(1,2,3), "a"]
+absl::Status ExtractFunctionRange(absl::string_view query,
+                                  int row,
+                                  int column,
+                                  std::unique_ptr<FunctionRange> *output);
+
+}
+
+#endif //ZETASQL_HELPER_ZETASQL_HELPER_FUNCTION_LOCATE_FUNCTION_H_

--- a/tools/zetasql_helper/zetasql_helper/scanner/extract_function.h
+++ b/tools/zetasql_helper/zetasql_helper/scanner/extract_function.h
@@ -33,7 +33,7 @@ struct FunctionRange {
   zetasql::ParseLocationRange name;
   std::vector<zetasql::ParseLocationRange> arguments;
 
-  FunctionRange(const zetasql::ASTFunctionCall *function_call);
+  FunctionRange(const zetasql::ASTFunctionCall& function_call);
 
   // Serialize the FunctionRange to its Protobuf object.
   zetasql_base::StatusOr<FunctionRangeProto> ToProto() const;
@@ -53,7 +53,7 @@ struct FunctionRange {
 absl::Status ExtractFunctionRange(absl::string_view query,
                                   int row,
                                   int column,
-                                  std::unique_ptr<FunctionRange> *output);
+                                  std::unique_ptr<FunctionRange>* output);
 
 }
 

--- a/tools/zetasql_helper/zetasql_helper/scanner/extract_function.h
+++ b/tools/zetasql_helper/zetasql_helper/scanner/extract_function.h
@@ -4,6 +4,21 @@
 
 #ifndef ZETASQL_HELPER_ZETASQL_HELPER_FUNCTION_LOCATE_FUNCTION_H_
 #define ZETASQL_HELPER_ZETASQL_HELPER_FUNCTION_LOCATE_FUNCTION_H_
+//
+// Copyright 2020 BigQuery Utils
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 
 #include "zetasql/public/parse_location.h"
 #include "zetasql/parser/parse_tree.h"

--- a/tools/zetasql_helper/zetasql_helper/scanner/function_range.proto
+++ b/tools/zetasql_helper/zetasql_helper/scanner/function_range.proto
@@ -1,0 +1,29 @@
+//
+// Copyright 2020 Mingen Pan
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto2";
+
+package bigquery.utils.zetasql_helper;
+
+import "zetasql/public/parse_location_range.proto";
+
+option java_package = "com.google.bigquery.utils.zetasqlhelper";
+
+message FunctionRangeProto {
+  optional zetasql.ParseLocationRangeProto function = 1;
+  optional zetasql.ParseLocationRangeProto name = 2;
+  repeated zetasql.ParseLocationRangeProto arguments = 3;
+}

--- a/tools/zetasql_helper/zetasql_helper/scanner/function_range.proto
+++ b/tools/zetasql_helper/zetasql_helper/scanner/function_range.proto
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Mingen Pan
+// Copyright 2020 BigQuery Utils
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/zetasql_helper/zetasql_helper/scanner/locate_table.cc
+++ b/tools/zetasql_helper/zetasql_helper/scanner/locate_table.cc
@@ -1,0 +1,45 @@
+//
+// Created by mepan on 8/24/20.
+//
+
+#include "locate_table.h"
+#include "zetasql/parser/parser.h"
+#include "zetasql_helper/util/util.h"
+#include "absl/strings/str_join.h"
+#include <regex>
+
+namespace bigquery::utils::zetasql_helper {
+
+absl::Status LocateTableRanges(absl::string_view query,
+                               absl::string_view table_regex,
+                               std::vector<zetasql::ParseLocationRange> &output) {
+
+  std::unique_ptr<zetasql::ParserOutput> parser_output;
+  auto options = BigQueryOptions();
+  ZETASQL_RETURN_IF_ERROR(ParseStatement(query, options.GetParserOptions(), &parser_output));
+
+  // Predicate to find a table whose name meets the table_rex
+  auto find_table = [table_regex](const zetasql::ASTNode *node) {
+    auto table_path = dynamic_cast<const zetasql::ASTTablePathExpression *>(node);
+    if (table_path == nullptr) {
+      return false;
+    }
+
+    // Read the full name of a table node.
+    auto names = read_names(*table_path->path_expr());
+    auto full_name = absl::StrJoin(names, ".");
+
+    return std::regex_match(full_name, std::regex(std::string(table_regex)));
+  };
+
+  auto table_nodes = find_all_nodes(parser_output->statement(), find_table);
+  for (auto table_node : table_nodes) {
+    output.push_back(table_node->GetParseLocationRange());
+  }
+
+  return absl::OkStatus();
+}
+
+}
+
+

--- a/tools/zetasql_helper/zetasql_helper/scanner/locate_table.cc
+++ b/tools/zetasql_helper/zetasql_helper/scanner/locate_table.cc
@@ -24,7 +24,7 @@ namespace bigquery::utils::zetasql_helper {
 
 absl::Status LocateTableRanges(absl::string_view query,
                                absl::string_view table_regex,
-                               std::vector<zetasql::ParseLocationRange> &output) {
+                               std::vector<zetasql::ParseLocationRange>& output) {
 
   std::unique_ptr<zetasql::ParserOutput> parser_output;
   auto options = BigQueryOptions();
@@ -45,7 +45,7 @@ absl::Status LocateTableRanges(absl::string_view query,
   };
 
   auto table_nodes = find_all_nodes(parser_output->statement(), find_table);
-  for (auto table_node : table_nodes) {
+  for (const auto table_node : table_nodes) {
     output.push_back(table_node->GetParseLocationRange());
   }
 

--- a/tools/zetasql_helper/zetasql_helper/scanner/locate_table.cc
+++ b/tools/zetasql_helper/zetasql_helper/scanner/locate_table.cc
@@ -1,5 +1,17 @@
 //
-// Created by mepan on 8/24/20.
+// Copyright 2020 BigQuery Utils
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 #include "locate_table.h"

--- a/tools/zetasql_helper/zetasql_helper/scanner/locate_table.h
+++ b/tools/zetasql_helper/zetasql_helper/scanner/locate_table.h
@@ -35,7 +35,7 @@ namespace bigquery::utils::zetasql_helper {
 absl::Status LocateTableRanges(
     absl::string_view query,
     absl::string_view table_regex,
-    std::vector<zetasql::ParseLocationRange> &output);
+    std::vector<zetasql::ParseLocationRange>& output);
 
 } //bigquery::utils::zetasql_helper
 

--- a/tools/zetasql_helper/zetasql_helper/scanner/locate_table.h
+++ b/tools/zetasql_helper/zetasql_helper/scanner/locate_table.h
@@ -1,0 +1,30 @@
+//
+// Created by mepan on 8/24/20.
+//
+
+#ifndef ZETASQL_HELPER_ZETASQL_HELPER_LOCATION_LOCATE_TABLE_H_
+#define ZETASQL_HELPER_ZETASQL_HELPER_LOCATION_LOCATE_TABLE_H_
+
+#include "zetasql/public/parse_location.h"
+#include "zetasql/parser/parse_tree.h"
+#include "zetasql_helper/util/util.h"
+
+namespace bigquery::utils::zetasql_helper {
+
+// Find the ranges [start byte offset - end byte offset) of all occurrences of the tables
+// meeting the table_name_regex. A table name is considered as [[project.]dataset.]table, and no
+// backtick will be included even they exist in the original query.
+//
+// Therefore `a`.b.c => a.b.c, `b.c` => b.c
+//
+// Input is a SQL query and the regex to match table name. The found table ranges will be pushed back
+// into the output vector. If an error occurs inside this function, a status with the error will be
+// returned. Otherwise, a OKStatus will be returned.
+absl::Status LocateTableRanges(
+    absl::string_view query,
+    absl::string_view table_regex,
+    std::vector<zetasql::ParseLocationRange> &output);
+
+} //bigquery::utils::zetasql_helper
+
+#endif //ZETASQL_HELPER_ZETASQL_HELPER_LOCATION_LOCATE_TABLE_H_

--- a/tools/zetasql_helper/zetasql_helper/scanner/locate_table.h
+++ b/tools/zetasql_helper/zetasql_helper/scanner/locate_table.h
@@ -1,5 +1,17 @@
 //
-// Created by mepan on 8/24/20.
+// Copyright 2020 BigQuery Utils
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 #ifndef ZETASQL_HELPER_ZETASQL_HELPER_LOCATION_LOCATE_TABLE_H_

--- a/tools/zetasql_helper/zetasql_helper/scanner/scanner_test.cc
+++ b/tools/zetasql_helper/zetasql_helper/scanner/scanner_test.cc
@@ -24,6 +24,12 @@ class LocationTest : public ::testing::Test {
 
 };
 
+std::string range_to_string(absl::string_view query, zetasql::ParseLocationRange& range) {
+  auto start = range.start().GetByteOffset();
+  auto length = range.end().GetByteOffset() - range.start().GetByteOffset();
+  return std::string(query.substr(start, length));
+}
+
 TEST_F(LocationTest, LocateTableTest1) {
   std::string query =
       "SELECT `特殊字符 (unicode characters)`, status FROM bigquery-public-data.`austin_311.311_request`"
@@ -37,14 +43,10 @@ TEST_F(LocationTest, LocateTableTest1) {
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(2, ranges.size());
-//  EXPECT_EQ(2, ranges[0].start().GetByteOffset())
+  EXPECT_EQ("bigquery-public-data.`austin_311.311_request`", range_to_string(query, ranges[0]));
+  EXPECT_EQ("`austin_311`.311_request", range_to_string(query, ranges[1]));
 }
 
-std::string range_to_string(absl::string_view query, zetasql::ParseLocationRange &range) {
-  auto start = range.start().GetByteOffset();
-  auto length = range.end().GetByteOffset() - range.start().GetByteOffset();
-  return std::string(query.substr(start, length));
-}
 
 TEST_F(LocationTest, LocateTableTest2) {
   std::string query = "Select max(foo) from bigquery-public-data.mock.survey_2017 group by bar limit 10";

--- a/tools/zetasql_helper/zetasql_helper/scanner/scanner_test.cc
+++ b/tools/zetasql_helper/zetasql_helper/scanner/scanner_test.cc
@@ -59,9 +59,9 @@ TEST_F(LocationTest, LocateTableTest2) {
 }
 
 TEST_F(LocationTest, ExtractFunction) {
-  std::string query = "select \"哈哈\", * from (select timestamp(10232) as x)";
+  std::string query = "select \"特殊字符 (unicode characters)\", * from (select timestamp(10232) as x)";
   int line = 1;
-  int col = 29;
+  int col = 52;
 
   std::unique_ptr<FunctionRange> output;
   auto status = ExtractFunctionRange(query, line, col, &output);
@@ -71,6 +71,6 @@ TEST_F(LocationTest, ExtractFunction) {
   EXPECT_EQ("timestamp(10232)", range_to_string(query, output->function));
   EXPECT_EQ(1, output->arguments.size());
   EXPECT_EQ("10232", range_to_string(query, output->arguments[0]));
-//  EXPECT_EQ(2, ranges[0].start().GetByteOffset())
+
 }
 

--- a/tools/zetasql_helper/zetasql_helper/scanner/scanner_test.cc
+++ b/tools/zetasql_helper/zetasql_helper/scanner/scanner_test.cc
@@ -1,3 +1,19 @@
+//
+// Copyright 2020 BigQuery Utils
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 #include "gtest/gtest.h"
 #include "zetasql_helper/scanner/locate_table.h"
 #include "zetasql_helper/scanner/extract_function.h"
@@ -10,7 +26,8 @@ class LocationTest : public ::testing::Test {
 
 TEST_F(LocationTest, LocateTableTest1) {
   std::string query =
-      "SELECT `哈哈`, status FROM bigquery-public-data.`austin_311.311_request` cross join `austin_311`.311_request\n"
+      "SELECT `特殊字符 (unicode characters)`, status FROM bigquery-public-data.`austin_311.311_request`"
+      "cross join `austin_311`.311_request\n"
       "where status = '`bigquery-public-data.austin_311.311_request`'";
 
   std::string table_regex = "(bigquery-public-data.)?austin_311.311_request";

--- a/tools/zetasql_helper/zetasql_helper/scanner/scanner_test.cc
+++ b/tools/zetasql_helper/zetasql_helper/scanner/scanner_test.cc
@@ -1,0 +1,59 @@
+#include "gtest/gtest.h"
+#include "zetasql_helper/scanner/locate_table.h"
+#include "zetasql_helper/scanner/extract_function.h"
+
+using namespace bigquery::utils::zetasql_helper;
+
+class LocationTest : public ::testing::Test {
+
+};
+
+TEST_F(LocationTest, LocateTableTest1) {
+  std::string query =
+      "SELECT `哈哈`, status FROM bigquery-public-data.`austin_311.311_request` cross join `austin_311`.311_request\n"
+      "where status = '`bigquery-public-data.austin_311.311_request`'";
+
+  std::string table_regex = "(bigquery-public-data.)?austin_311.311_request";
+
+  std::vector<zetasql::ParseLocationRange> ranges;
+  auto status = LocateTableRanges(query, table_regex, ranges);
+
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(2, ranges.size());
+//  EXPECT_EQ(2, ranges[0].start().GetByteOffset())
+}
+
+std::string range_to_string(absl::string_view query, zetasql::ParseLocationRange &range) {
+  auto start = range.start().GetByteOffset();
+  auto length = range.end().GetByteOffset() - range.start().GetByteOffset();
+  return std::string(query.substr(start, length));
+}
+
+TEST_F(LocationTest, LocateTableTest2) {
+  std::string query = "Select max(foo) from bigquery-public-data.mock.survey_2017 group by bar limit 10";
+  std::string table_regex = "bigquery-public-data\\.mock\\.survey_2017";
+
+  std::vector<zetasql::ParseLocationRange> ranges;
+  auto status = LocateTableRanges(query, table_regex, ranges);
+
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(1, ranges.size());
+//  EXPECT_EQ(2, ranges[0].start().GetByteOffset())
+}
+
+TEST_F(LocationTest, ExtractFunction) {
+  std::string query = "select \"哈哈\", * from (select timestamp(10232) as x)";
+  int line = 1;
+  int col = 29;
+
+  std::unique_ptr<FunctionRange> output;
+  auto status = ExtractFunctionRange(query, line, col, &output);
+
+  ASSERT_TRUE(status.ok());
+  EXPECT_EQ("timestamp", range_to_string(query, output->name));
+  EXPECT_EQ("timestamp(10232)", range_to_string(query, output->function));
+  EXPECT_EQ(1, output->arguments.size());
+  EXPECT_EQ("10232", range_to_string(query, output->arguments[0]));
+//  EXPECT_EQ(2, ranges[0].start().GetByteOffset())
+}
+


### PR DESCRIPTION
Develop ExtractFunctionRange, LocateTableRanges, and GetAllKeywords methods
RPC calls are added
Test cases are included.