### PR TITLE
Adding levenshtein to bigquery-utils

### DIFF
--- a/udfs/community/README.md
+++ b/udfs/community/README.md
@@ -22,6 +22,7 @@ SELECT bqutil.fn.int(1.684)
 * [json_typeof](#json_typeofjson-string)
 * [kruskal_wallis](#kruskal_wallisarraystructfactor-string-val-float64)
 * [last_day](#lastdaydt-date)
+* [levenshtein](#levenshteinsource-string-target-string-returns-int64)
 * [linear_interpolate](#linear_interpolatepos-int64-prev-structx-int64-y-float64-next-structx-int64-y-float64)
 * [linear_regression](#linear_regressionarraystructstructx-float64-y-float64)
 * [median](#medianarr-any-type)
@@ -237,6 +238,36 @@ results:
 |     f0_    |     f1_    |     f2_    |     f3_    |
 |------------|------------|------------|------------|
 | 1987-12-31 | 1998-09-30 | 2020-02-29 | 2019-02-28 |
+
+
+### [levenshtein(source STRING, target STRING) RETURNS INT64](levenshtein.sql)
+Returns an integer number indicating the degree of similarity between two strings (0=identical, 1=single character difference, etc.)
+
+```sql
+SELECT
+  source,
+  target,
+  bqutil.fn.levenshtein(source, target) distance,
+FROM UNNEST([
+  STRUCT('analyze' AS source, 'analyse' AS target),
+  STRUCT('opossum', 'possum'),
+  STRUCT('potatoe', 'potatoe'),
+  STRUCT('while', 'whilst'),
+  STRUCT('aluminum', 'alumininium'),
+  STRUCT('Connecticut', 'CT')
+]);
+```
+
+Row | source      | target      | distance
+--- | ----------- | ----------- | ---------
+1   |	analyze     | analyse     | 1
+2   | opossum     | possum      | 1
+3   | potatoe     | potatoe     | 0
+4   | while       | whilst      | 2
+5   | aluminum    | alumininium | 3
+6   | Connecticut | CT          | 10
+
+> This function is based on the [Levenshtein distance algorithm](https://en.wikipedia.org/wiki/Levenshtein_distance) which determines the minimum number of single-character edits (insertions, deletions or substitutions) required to change one source string into another target one.
 
 
 ### [linear_interpolate(pos INT64, prev STRUCT<x INT64, y FLOAT64>, next STRUCT<x INT64, y FLOAT64>)](linear_interpolate.sql)

--- a/udfs/community/levenshtein.sql
+++ b/udfs/community/levenshtein.sql
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+CREATE OR REPLACE FUNCTION fn.levenshtein(source STRING, target STRING)
+RETURNS INT64
+LANGUAGE js
+AS
+"""
+  return js_levenshtein(source || '', target || '');
+"""
+OPTIONS (library="${JS_BUCKET}/js-levenshtein-v1.1.6.js"));

--- a/udfs/community/levenshtein.sql
+++ b/udfs/community/levenshtein.sql
@@ -21,4 +21,6 @@ AS
 """
   return js_levenshtein(source || '', target || '');
 """
-OPTIONS (library="${JS_BUCKET}/js-levenshtein-v1.1.6.js"));
+OPTIONS (
+  library="${JS_BUCKET}/js-levenshtein-v1.1.6.js"
+);

--- a/udfs/community/test_cases.yaml
+++ b/udfs/community/test_cases.yaml
@@ -389,6 +389,25 @@ nlp_compromise_people:
   - test:
     input: CAST("Randal Kieth Orton and Dwayne 'the rock' Johnson had a really funny fight." AS STRING)
     expected_output: CAST(['randal kieth orton', 'dwayne the rock johnson'] AS ARRAY<STRING>)
+levenshtein:
+  - test:
+    input: CAST('analyze' AS STRING), CAST('analyse' AS STRING)
+    expected_output: CAST(1 AS INT64)
+  - test:
+    input: CAST('opossum' AS STRING), CAST('possum' AS STRING)
+    expected_output: CAST(1 AS INT64)
+  - test:
+    input: CAST('potatoe' AS STRING), CAST('potatoe' AS STRING)
+    expected_output: CAST(0 AS INT64)
+  - test:
+    input: CAST('while' AS STRING), CAST('whilst' AS STRING)
+    expected_output: CAST(2 AS INT64)
+  - test:
+    input: CAST('aluminum' AS STRING), CAST('alumininium' AS STRING)
+    expected_output: CAST(3 AS INT64)
+  - test:
+    input: CAST('Connecticut' AS STRING), CAST('CT' AS STRING)
+    expected_output: CAST(10 AS INT64)
 #
 # Below targets StatsLib work
 #


### PR DESCRIPTION
A UDF that computes the [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance) between two strings. 

This code is based on the 2019 PR #26 by @davetemplin, still unmerged, adding all the suggestions (.js file hosting process, test cases) by @danieldeleo.

## Tests

I've followed the instructions at [CONTRIBUTING.md](https://github.com/GoogleCloudPlatform/bigquery-utils/blob/master/udfs/CONTRIBUTING.md) but I get an error related to the JS location bucket

```
/home/sergi/.local/share/virtualenvs/udfs-xmmKslJq/lib/python3.9/site-packages/google/cloud/bigquery/job/base.py:662: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <google.cloud.bigquery.job.query.QueryJob object at 0x7fa8cb9816d0>, timeout = None
retry = <google.api_core.retry.Retry object at 0x7fa8cc5213a0>

    def result(self, timeout=None, retry=DEFAULT_RETRY):
        """Get the result of the operation, blocking if necessary.
    
        Args:
            timeout (int):
                How long (in seconds) to wait for the operation to complete.
                If None, wait indefinitely.
    
        Returns:
            google.protobuf.Message: The Operation's result.
    
        Raises:
            google.api_core.GoogleAPICallError: If the operation errors or if
                the timeout is reached before the operation completes.
        """
        kwargs = {} if retry is DEFAULT_RETRY else {"retry": retry}
        self._blocking_poll(timeout=timeout, **kwargs)
    
        if self._exception is not None:
            # pylint: disable=raising-bad-type
            # Pylint doesn't recognize that this is valid in this case.
>           raise self._exception
E           google.api_core.exceptions.Forbidden: 403 Access Denied: BigQuery BigQuery: Error getting metadata for external code resource, please verify you have provided a valid path and/or that you have access to the resource: ${JS_BUCKET}/js-levenshtein-v1.1.6.js
E           
E           (job ID: 4ec0cc13-9381-4d29-be1d-45806b41aaa3)
E           
E                                                        -----Query Job SQL Follows-----                                              
E           
E               |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |
E              1:SELECT `fn_test_local_test.levenshtein`( CAST('analyze' AS STRING), CAST('analyse' AS STRING) ) AS actual_result_rows
E               |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |

/home/sergi/.local/share/virtualenvs/udfs-xmmKslJq/lib/python3.9/site-packages/google/api_core/future/polling.py:134: Forbidden

During handling of the above exception, another exception occurred:

a = (<test_run_udfs.TestRunUDFs testMethod=test_run_udf_and_verify_expected_result_33__community_levenshtein_sql>,)

    @wraps(func)
    def standalone_func(*a):
>       return func(*(a + p.args), **p.kwargs)

/home/sergi/.local/share/virtualenvs/udfs-xmmKslJq/lib/python3.9/site-packages/parameterized/parameterized.py:533: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/test_run_udfs.py:83: in test_run_udf_and_verify_expected_result
    self.fail(error.message)
E   AssertionError: Access Denied: BigQuery BigQuery: Error getting metadata for external code resource, please verify you have provided a valid path and/or that you have access to the resource: ${JS_BUCKET}/js-levenshtein-v1.1.6.js
E   
E   (job ID: 4ec0cc13-9381-4d29-be1d-45806b41aaa3)
E   
E                                                -----Query Job SQL Follows-----                                              
E   
E       |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |
E      1:SELECT `fn_test_local_test.levenshtein`( CAST('analyze' AS STRING), CAST('analyse' AS STRING) ) AS actual_result_rows
E       |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |    .    |
======================================= short test summary info ========================================
FAILED tests/test_run_udfs.py::TestRunUDFs::test_run_udf_and_verify_expected_result_33__community_levenshtein_sql
```

### Notes

Python 3.9 is the default Python version in a lot of modern Linux distributions, but [Parallel Pytest](https://github.com/browsertron/pytest-parallel/issues/89) still does not support it, so tests will always fail. 


