### PR TITLE
feat: implement jstat_udf

### DIFF
--- a/udfs/community/jstat.sql
+++ b/udfs/community/jstat.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE FUNCTION fn.jstat(method STRING, args ARRAY<FLOAT64>)
+RETURNS FLOAT64
+LANGUAGE js AS """
+    const methodPath = method['split']('.')
+    let fn = jstat['jStat']
+    for (const name of methodPath){
+        fn = fn[name]
+    }
+
+  return fn(...args)
+"""
+OPTIONS (
+	    library=["${JS_BUCKET}/jstat-v1.9.4.min.js"]
+);

--- a/udfs/community/test_cases.yaml
+++ b/udfs/community/test_cases.yaml
@@ -411,6 +411,10 @@ levenshtein:
 #
 # Below targets StatsLib work
 #
+jstat:
+  - test:
+    input: CAST('chisquare.cdf' AS STRING), ARRAY<FLOAT64>[0.3, 2.0]
+    expected_output: CAST(0.1392920235749422 AS FLOAT64)
 pvalue:
   - test:
     input: CAST(0.3 AS FLOAT64), CAST(2 AS INT64)


### PR DESCRIPTION
@jrossthomson @boaguilar I just did a little bit of experimentation to wrap the `jstat` library in a single UDF  — at first pass, it seems that this unfortunately won't be possible for all jStat methods, but maybe achievable for those that take a list of floats as their arguments and return a single scalar float.

My naive attempt was to do something like below, where `args` is an array of arguments to pass to the jstat function:
```sql
CREATE OR REPLACE FUNCTION fn.jstat(method STRING, args ANY TYPE)
RETURNS ANY TYPE
LANGUAGE js AS """
    const methodPath = method.split('.')
    let fn = jstat['jStat']
    for (const name of methodPath){
        fn = fn[name]
    }
   
  return fn(...args)
"""
OPTIONS (
	    library=["${JS_BUCKET}/jstat-v1.9.4.min.js"]
);
```

You would invoke the method like so:
```sql
SELECT fns.jstat('chisquare.cdf',  ARRAY<FLOAT64>[0.3, 2.0])
```

However, the `ANY_TYPE` parameter is currently [only supported in SQL UDFs](https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions#templated-sql-udf-parameters), not JS UDFs. Moreover, `ANY_TYPE` isn't supported as the return type for UDFs.

Many of the [jstat functions](https://jstat.github.io/all.html) expect floats as their input and return a single float scalar, so we _could_ implement this for just those cases, which is what I've done here. Not sure if we want to merge this, or maybe others have an idea of a better approach.

The function implemented in this PR is as below:

```sql
CREATE OR REPLACE FUNCTION fn.jstat(method STRING, args ARRAY<FLOAT64>)
RETURNS FLOAT64
LANGUAGE js AS """
    const methodPath = method['split']('.')
    let fn = jstat['jStat']
    for (const name of methodPath){
        fn = fn[name]
    }

  return fn(...args)
"""
OPTIONS (
	    library=["${JS_BUCKET}/jstat-v1.9.4.min.js"]
);

```
