### PR TITLE
Fix for js UDF dependency generation

### DIFF
--- a/udfs/tests/Dockerfile.ci
+++ b/udfs/tests/Dockerfile.ci
@@ -1,4 +1,5 @@
 FROM python:3.8.0-slim
+WORKDIR /ci
 COPY requirements.txt ./
 RUN pip3 install --no-cache-dir -r requirements.txt
 ENTRYPOINT ["pytest"]

--- a/udfs/tests/udf_test_utils.py
+++ b/udfs/tests/udf_test_utils.py
@@ -210,7 +210,7 @@ def generate_js_libs_package_json():
             "build-all-libs": "concurrently \"npm:webpack-*\""
         },
         "dependencies": {
-            f'{lib_name}-v{version}': f'npm:{lib_name}@^{version}'
+            f'{lib_name}-v{version}': f'npm:{lib_name}@{version}'
             for lib_name in js_libs_dict
             for version in js_libs_dict.get(lib_name).get('versions')
         },


### PR DESCRIPTION
Removing caret symbol from js libs specification so that the exact version of a library is built, instead of a greater version.