### PR TITLE
remove log4j dependency

### DIFF
--- a/tools/query_breakdown/pom.xml
+++ b/tools/query_breakdown/pom.xml
@@ -47,11 +47,6 @@
       <version>1.7.5</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.5</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>29.0-jre</version>

--- a/tools/query_breakdown/src/main/java/com/google/bigquery/Main.java
+++ b/tools/query_breakdown/src/main/java/com/google/bigquery/Main.java
@@ -10,8 +10,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.cli.*;
 
 import java.io.IOException;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.json.simple.JSONArray;
 import java.text.DecimalFormat;
 import org.json.simple.JSONObject;
@@ -39,9 +37,6 @@ import org.json.simple.JSONObject;
  */
 public class Main {
   public static void main(String[] args) {
-    // deals with slf4j logger errors from calcite parser
-    Logger.getRootLogger().setLevel(Level.OFF);
-
     // starts the timer for runtime measurement
     long start = System.nanoTime();
 


### PR DESCRIPTION
Remove log4j dependency. This log4j version is not between 2.0 and 2.15 and therefore not vulnerable. However, the version is quite low and not very useful, so remove the depdency.