### PR TITLE
Fix billing analytics SQL script

### DIFF
--- a/scripts/billing/sql/monthly_invoice_costs_credits.sql
+++ b/scripts/billing/sql/monthly_invoice_costs_credits.sql
@@ -5,11 +5,10 @@ taxes, adjustments, and rounding errors.
 
 SELECT
   invoice.month AS invoice_month,
-  SUM(cost) + SUM(IFNULL(credits.amount, 0)) AS total,
+  SUM(cost) + SUM((SELECT SUM(amount) FROM UNNEST(credits))) AS total,
   (SUM(CAST(cost * 1000000 AS INT64)) +
-    SUM(IFNULL(CAST(credits.amount * 1000000 AS INT64), 0))) / 1000000
+    SUM((SELECT SUM(CAST(amount * 1000000 AS INT64)) FROM UNNEST(credits)))) / 1000000
     AS total_exact
 FROM `bqutil.billing.billing_dashboard_export`
-LEFT JOIN UNNEST(credits) AS credits
 GROUP BY invoice_month
 ORDER BY invoice_month ASC


### PR DESCRIPTION
**Issue**

BigQuery billing analytics [monthly_invoice_costs_credits.sql](https://github.com/GoogleCloudPlatform/bigquery-utils/blob/master/scripts/billing/sql/monthly_invoice_costs_credits.sql) script uses join to unnest credits and adds them to total cost. This produces duplicate cost rows and incorrect total cost when there is more than one credit applied to the same line item.

![image](https://user-images.githubusercontent.com/19743282/172159452-5e1c81dc-3519-492f-b1aa-f7e65e83ccc7.png)

**Fix**

Join is replaced with subquery to prevent duplication of rows which fixes the total cost.
