### PR TITLE
Adding explicit logging option to deploy.yaml

### DIFF
--- a/udfs/deploy.yaml
+++ b/udfs/deploy.yaml
@@ -1,16 +1,12 @@
-# Google Cloud Build script to deploy bqutils UDFs in your own project
-#
-# This build script is used to unit test.sql the BigQuery UDFs for every
-# change pushed to the udfs/ directory.
+# Google Cloud Build config to deploy bqutils
+# BigQuery UDFs in your own project and location
 #
 # Manual Execution:
-# Use the below command to invoke the build manually. Note the substitutions for
-# BRANCH_NAME and REVISION_ID. These variables are normally populated when the
-# build is executed via build triggers but will be empty during manual
-# execution. Dummy branch and revisions can be passed during manual execution so
-# the artifacts can be uploaded upon build completion.
+# Use the below command to invoke the build manually.
+# Note the substitutions for _PROJECT_ID and _BQ_LOCATION.
 #
-# gcloud builds submit . --substitutions _BQ_LOCATION=
+# Example Run:
+# gcloud builds submit . --substitutions _PROJECT_ID=YOUR_PROJECT_ID,_BQ_LOCATION=US
 #
 
 steps:
@@ -18,7 +14,7 @@ steps:
 # Deploy UDFs and run unit tests
 ###########################################################
 - name: gcr.io/bqutil/bq_udf_ci
-  id: test_udfs
+  id: deploy_and_test_udfs
   dir: tests/dataform_testing_framework
   entrypoint: bash
   args:
@@ -28,3 +24,5 @@ steps:
     - BQ_LOCATION=${_BQ_LOCATION}
     - SHORT_SHA=
     - JS_BUCKET=gs://bqutil-lib/bq_js_libs
+options:
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
This PR addresses the following error when invoking `deploy.yaml` with a user-specified build service account:

```
Your build failed to run: generic::invalid_argument: generic::invalid_argument: if 'build.service_account' is specified, the build must either (a) specify 'build.logs_bucket' (b) use the CLOUD_LOGGING_ONLY logging option, or (c) use the NONE logging option
```