### PR TITLE
Patch: enable UDF "url_param" to handle tildes and underscores

### DIFF
--- a/udfs/community/README.md
+++ b/udfs/community/README.md
@@ -815,7 +815,7 @@ SELECT bqutil.fn.url_param(
 ```
 
 
-### [url_parse(urlString STRING, partToExtract STRING)](url_parse_udf.sqlx)
+### [url_parse(urlString STRING, partToExtract STRING)](url_parse.sqlx)
 
 Returns the specified part from the URL. Valid values for partToExtract include HOST, PATH, QUERY, REF, PROTOCOL
 For example, url_parse('http://facebook.com/path1/p.php?k1=v1&k2=v2#Ref1', 'HOST') returns 'facebook.com'.

--- a/udfs/community/test_cases.js
+++ b/udfs/community/test_cases.js
@@ -413,6 +413,13 @@ generate_udf_test("url_parse", [
     },
     {
         inputs: [
+            `"http://facebook.com/~tilde/hy-phen/do.t/under_score.php?k1=v1&k2=v2#Ref1"`,
+            `"PATH"`
+        ],
+        expected_output: `"~tilde/hy-phen/do.t/under_score.php"`
+    },
+    {
+        inputs: [
             `"subdomain.facebook.com/path1/p.php?k1=v1&k2=v2#Ref1"`,
             `"PATH"`
         ],

--- a/udfs/community/url_parse.sqlx
+++ b/udfs/community/url_parse.sqlx
@@ -22,7 +22,7 @@ CREATE OR REPLACE FUNCTION ${self()}(url STRING, part STRING)
 AS (
   CASE
     WHEN UPPER(part) = 'HOST'  THEN REGEXP_EXTRACT(url, r'(?:[a-zA-Z]+://)?([a-zA-Z0-9-.]+)/?')
-    WHEN UPPER(part) = 'PATH'  THEN REGEXP_EXTRACT(url, r'(?:[a-zA-Z]+://)?(?:[a-zA-Z0-9-.]+)/{1}([a-zA-Z0-9-./]+)')
+    WHEN UPPER(part) = 'PATH'  THEN REGEXP_EXTRACT(url, r'(?:[a-zA-Z]+://)?(?:[a-zA-Z0-9-.]+)/{1}([a-zA-Z0-9-.~_/]+)')
     WHEN UPPER(part) = 'QUERY' THEN REGEXP_EXTRACT(url, r'\?(.*)')
     WHEN UPPER(part) = 'REF'   THEN REGEXP_EXTRACT(url, r'#(.*)')
     WHEN UPPER(part) = 'PROTOCOL' THEN REGEXP_EXTRACT(url, r'^([a-zA-Z]+)://')


### PR DESCRIPTION
We can use underscore and tilde in URL. I have made them capturable.

> Characters that are allowed in a URI but do not have a reserved
> purpose are called unreserved. These include uppercase and lowercase
> letters, decimal digits, hyphen, period, underscore, and tilde.

- [RFC 3986: Uniform Resource Identifier (URI): Generic Syntax](https://www.rfc-editor.org/rfc/rfc3986#section-2.3)