### PR TITLE
Parameterize the deploy.yaml build config working directory 

### DIFF
--- a/udfs/deploy.yaml
+++ b/udfs/deploy.yaml
@@ -15,7 +15,7 @@ steps:
 ###########################################################
 - name: gcr.io/bqutil/bq_udf_ci
   id: deploy_and_test_udfs
-  dir: tests/dataform_testing_framework
+  dir: ${_WORKING_DIR}
   entrypoint: bash
   args:
     - deploy_and_run_tests.sh
@@ -24,5 +24,8 @@ steps:
     - BQ_LOCATION=${_BQ_LOCATION}
     - SHORT_SHA=
     - JS_BUCKET=gs://bqutil-lib/bq_js_libs
+substitutions:
+  _WORKING_DIR: tests/dataform_testing_framework # default value when submitting from udfs/ directory
 options:
   logging: CLOUD_LOGGING_ONLY
+


### PR DESCRIPTION
Parameterizing the dir attribute in the deploy.yaml config allows:

- Users to manually submit builds from the udfs/ directory using gcloud 
- Build triggers at repo root level can override this attribute to prevent path failures