### PR TITLE
typeof() UDF improvement: correctly identify single quoted string

### DIFF
--- a/udfs/community/test_cases.js
+++ b/udfs/community/test_cases.js
@@ -153,6 +153,10 @@ generate_udf_test("typeof", [
         inputs: [`""`],
         expected_output: `"STRING"`
     },
+    {
+        inputs: [`'string containing " double-quote'`],
+        expected_output: `"STRING"`
+    },
 ]);
 generate_udf_test("typeof", [
     {

--- a/udfs/community/typeof.sqlx
+++ b/udfs/community/typeof.sqlx
@@ -27,7 +27,7 @@ AS ( (
         WHEN REGEXP_CONTAINS(literal, r'^-?[0-9]*$') THEN 'INT64'
         WHEN REGEXP_CONTAINS(literal, r'^(-?[0-9]+[.e].*|CAST\("([^"]*)" AS FLOAT64\))$') THEN 'FLOAT64'
         WHEN literal IN ('true', 'false') THEN 'BOOL'
-        WHEN literal LIKE '"%' or literal LIKE "'%" THEN 'STRING'
+        WHEN literal LIKE '"%' OR literal LIKE "'%" THEN 'STRING'
         WHEN literal LIKE 'b"%' THEN 'BYTES'
         WHEN literal LIKE '[%' THEN 'ARRAY'
         WHEN REGEXP_CONTAINS(literal, r'^(STRUCT)?\(') THEN 'STRUCT'

--- a/udfs/community/typeof.sqlx
+++ b/udfs/community/typeof.sqlx
@@ -27,7 +27,7 @@ AS ( (
         WHEN REGEXP_CONTAINS(literal, r'^-?[0-9]*$') THEN 'INT64'
         WHEN REGEXP_CONTAINS(literal, r'^(-?[0-9]+[.e].*|CAST\("([^"]*)" AS FLOAT64\))$') THEN 'FLOAT64'
         WHEN literal IN ('true', 'false') THEN 'BOOL'
-        WHEN literal LIKE '"%' THEN 'STRING'
+        WHEN literal LIKE '"%' or literal LIKE "'%" THEN 'STRING'
         WHEN literal LIKE 'b"%' THEN 'BYTES'
         WHEN literal LIKE '[%' THEN 'ARRAY'
         WHEN REGEXP_CONTAINS(literal, r'^(STRUCT)?\(') THEN 'STRUCT'


### PR DESCRIPTION
Improvement to the `typeof()` UDF: correctly recognize more (all?) strings.


`FORMAT('%T', <string value>)` will return a string with single quotes if the passed string value contains a double quote (`"`) and no single quotes (`'`). `typeof()` would no recognize that as a string, and return `"UNKNOWN"`.