### PR TITLE
Handling Invalid input for  `fn.json_extract_keys`,  `fn.json_extract_values`

### DIFF
--- a/udfs/community/README.md
+++ b/udfs/community/README.md
@@ -786,7 +786,7 @@ Takes input string and delimiter. It generates pair from string tokenizer.
 ```sql
 SELECT bqutil.fn.cw_strtok('Test#1', '#');
 
-([STRUCT(CAST(1 AS INT64) AS tokennumber, "Test" AS token), 
+([STRUCT(CAST(1 AS INT64) AS tokennumber, "Test" AS token),
 STRUCT(CAST(2 AS INT64) AS tokennumber, "1" AS token)])
 ```
 
@@ -795,7 +795,7 @@ Takes input string, delimiter and flags. It generates pair from string tokenizer
 ```sql
 SELECT bqutil.fn.cw_regexp_split('Test#1', '#', 'i');
 
-([STRUCT(CAST(1 AS INT64) AS tokennumber, "Test" AS token), 
+([STRUCT(CAST(1 AS INT64) AS tokennumber, "Test" AS token),
 STRUCT(CAST(2 AS INT64) AS tokennumber, "1" AS token)])
 ```
 
@@ -867,7 +867,7 @@ String to map convert.
 ```sql
 SELECT bqutil.fn.cw_map_parse("a=1 b=42", " ", "=");
 
-([STRUCT("a" AS key, "1" AS value), 
+([STRUCT("a" AS key, "1" AS value),
 STRUCT("b" AS key, "42" AS value)])
 ```
 
@@ -1125,6 +1125,7 @@ SELECT
 
 ### [json_extract_keys()](json_extract_keys.sqlx)
 Returns all keys in the input JSON as an array of string
+Returns NULL if invalid JSON string is passed,
 
 ```sql
 SELECT bqutil.fn.json_extract_keys(
@@ -1138,6 +1139,8 @@ hat
 
 ### [json_extract_values()](json_extract_values.sqlx)
 Returns all values in the input JSON as an array of string
+Returns NULL if invalid JSON string is passed,
+
 
 ```sql
 SELECT bqutil.fn.json_extract_values(

--- a/udfs/community/json_extract_keys.sqlx
+++ b/udfs/community/json_extract_keys.sqlx
@@ -21,5 +21,18 @@ config { hasOutput: true }
 CREATE OR REPLACE FUNCTION ${self()}(input STRING)
 RETURNS Array<String>
 LANGUAGE js AS """
-  return Object.keys(JSON.parse(input));
+  if(input === null) {
+    return null;
+  }
+
+  let obj;
+  try {
+    obj = JSON.parse(input);
+  } catch {
+    return null;
+  }
+  if(!obj) {
+    return null;
+  }
+  return Object.keys(obj);
 """;

--- a/udfs/community/json_extract_keys.sqlx
+++ b/udfs/community/json_extract_keys.sqlx
@@ -21,18 +21,9 @@ config { hasOutput: true }
 CREATE OR REPLACE FUNCTION ${self()}(input STRING)
 RETURNS Array<String>
 LANGUAGE js AS """
-  if(input === null) {
-    return null;
-  }
-
-  let obj;
   try {
-    obj = JSON.parse(input);
+    return Object.keys(JSON.parse(input));
   } catch {
     return null;
   }
-  if(!obj) {
-    return null;
-  }
-  return Object.keys(obj);
 """;

--- a/udfs/community/json_extract_keys.sqlx
+++ b/udfs/community/json_extract_keys.sqlx
@@ -20,7 +20,22 @@ config { hasOutput: true }
 */
 CREATE OR REPLACE FUNCTION ${self()}(input STRING)
 RETURNS Array<String>
-LANGUAGE js AS """
+LANGUAGE js 
+OPTIONS (description="""Returns all keys in the input JSON as an array of string
+Returns NULL if invalid JSON string is passed,
+
+```sql
+SELECT bqutil.fn.json_extract_keys(
+  '{"foo" : "cat", "bar": "dog", "hat": "rat"}'
+) AS keys_array
+
+foo
+bar
+hat
+```
+"""
+)
+AS """
   try {
     return Object.keys(JSON.parse(input));
   } catch {

--- a/udfs/community/json_extract_values.sqlx
+++ b/udfs/community/json_extract_values.sqlx
@@ -21,17 +21,9 @@ config { hasOutput: true }
 CREATE OR REPLACE FUNCTION ${self()}(input STRING)
 RETURNS Array<String>
 LANGUAGE js AS """
-  if(input === null) {
-    return null;
-  }
-  let obj;
   try {
-    obj = JSON.parse(input);
+    return Object.values(JSON.parse(input));
   } catch {
     return null;
   }
-  if(!obj) {
-    return null;
-  }
-  return Object.values(obj);
 """;

--- a/udfs/community/json_extract_values.sqlx
+++ b/udfs/community/json_extract_values.sqlx
@@ -21,5 +21,17 @@ config { hasOutput: true }
 CREATE OR REPLACE FUNCTION ${self()}(input STRING)
 RETURNS Array<String>
 LANGUAGE js AS """
-  return Object.values(JSON.parse(input));
+  if(input === null) {
+    return null;
+  }
+  let obj;
+  try {
+    obj = JSON.parse(input);
+  } catch {
+    return null;
+  }
+  if(!obj) {
+    return null;
+  }
+  return Object.values(obj);
 """;

--- a/udfs/community/json_extract_values.sqlx
+++ b/udfs/community/json_extract_values.sqlx
@@ -15,12 +15,26 @@ config { hasOutput: true }
  * limitations under the License.
  */
 
-/*
-  Returns all values in the input JSON as an array of string
-*/
 CREATE OR REPLACE FUNCTION ${self()}(input STRING)
 RETURNS Array<String>
-LANGUAGE js AS """
+LANGUAGE js 
+OPTIONS(
+  description = """Returns all values in the input JSON as an array of string
+Returns NULL if invalid JSON string is passed,
+
+
+```sql
+SELECT bqutil.fn.json_extract_values(
+  '{"foo" : "cat", "bar": "dog", "hat": "rat"}'
+) AS keys_array
+
+cat
+dog
+rat
+```
+"""
+) 
+AS """
   try {
     return Object.values(JSON.parse(input));
   } catch {

--- a/udfs/community/test_cases.js
+++ b/udfs/community/test_cases.js
@@ -49,6 +49,14 @@ generate_udf_test("json_extract_keys", [
         inputs: [`'{"int" : 1}'`],
         expected_output: `["int"]`
     },
+    {
+        inputs: [`'invalid_json'`],
+        expected_output: `cast(null as array<string>)`,
+    },
+    {
+        inputs: [`string(null)`],
+        expected_output: `cast(null as array<string>)`,
+    },
 ]);
 generate_udf_test("json_extract_values", [
     {
@@ -58,6 +66,14 @@ generate_udf_test("json_extract_values", [
     {
         inputs: [`'{"int" : 1}'`],
         expected_output: `["1"]`
+    },
+    {
+        inputs: [`'invalid_json'`],
+        expected_output: `cast(null as array<string>)`,
+    },
+    {
+        inputs: [`string(null)`],
+        expected_output: `cast(null as array<string>)`,
     },
 ]);
 generate_udf_test("json_typeof", [


### PR DESCRIPTION
In BigQuery SQL function behavior,
function typically would return null for invalid arguments, not causing runtime error. JavaScript UDF currently does.

The difference is not useful for users because it gives users extra attention to use JavaScript UDFs

This PR fixes behavior of json_extract_keys, json_extract_values