### PR TITLE
Add Protobuf Export to BigQueryUtils/Tools

### DIFF
--- a/tools/protobuf_export/.gitignore
+++ b/tools/protobuf_export/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tools/protobuf_export/.gitignore
+++ b/tools/protobuf_export/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+dist/

--- a/tools/protobuf_export/README.md
+++ b/tools/protobuf_export/README.md
@@ -1,0 +1,38 @@
+# BigQuery Protobuf Export
+
+## Introduction
+When querying BigQuery, it is sometimes required to export data as protobuf bytes. 
+This can be useful for coding purposes, where we may want an elaborate data
+type to be exported.
+
+## Procedure
+1. Clone this reposiory.
+2. Add your proto files under `protos` folder.
+3. Run `npm install`.
+4. Run `npx webpack --config webpack.config.js --stats-error-details`.
+5. Copy the file from dist folder (`dist/pbwrapper.js`) into GCS.
+6. Use the created script in a BigQuery User Defined Function like so:
+
+```
+CREATE FUNCTION
+  <namespace>.toProto(input STRUCT<word STRING,
+    wordCount BIGNUMERIC>,
+    protoMessage STRING)
+  RETURNS BYTES
+  LANGUAGE js OPTIONS ( library=["gs://{YOUR_GCS_BUCKET}/pbwrapper.js"] ) AS r"""
+let message = pbwrapper.setup(protoMessage)
+return pbwrapper.parse(message, input)
+ """;
+ ```
+ 7. Use the created function like so:
+```
+SELECT
+  <namespace>.toProto(STRUCT(word,
+      CAST(word_count AS BIGNUMERIC)),
+    "<proto package name>.<proto message name>") AS protoResult
+FROM
+  `bigquery-public-data.samples.shakespeare`
+```
+
+## Caveats
+1. While the same pbwrapper.js can be used for all .proto files under protos folder, you will still need to create one such function per proto message. That is due to the fact that BigQuery structs are fully typed.

--- a/tools/protobuf_export/README.md
+++ b/tools/protobuf_export/README.md
@@ -16,8 +16,7 @@ type to be exported.
 ```
 CREATE FUNCTION
   <namespace>.toMyProtoMessage(input STRUCT<word STRING,
-    wordCount BIGNUMERIC>,
-    protoMessage STRING)
+    wordCount BIGNUMERIC>)
   RETURNS BYTES
   LANGUAGE js OPTIONS ( library=["gs://{YOUR_GCS_BUCKET}/pbwrapper.js"] ) AS r"""
 let message = pbwrapper.setup("<proto package name>.<proto message name>")

--- a/tools/protobuf_export/README.md
+++ b/tools/protobuf_export/README.md
@@ -15,23 +15,24 @@ type to be exported.
 
 ```
 CREATE FUNCTION
-  <namespace>.toProto(input STRUCT<word STRING,
+  <namespace>.toMyProtoMessage(input STRUCT<word STRING,
     wordCount BIGNUMERIC>,
     protoMessage STRING)
   RETURNS BYTES
   LANGUAGE js OPTIONS ( library=["gs://{YOUR_GCS_BUCKET}/pbwrapper.js"] ) AS r"""
-let message = pbwrapper.setup(protoMessage)
+let message = pbwrapper.setup("<proto package name>.<proto message name>")
 return pbwrapper.parse(message, input)
  """;
  ```
  7. Use the created function like so:
 ```
 SELECT
-  <namespace>.toProto(STRUCT(word,
-      CAST(word_count AS BIGNUMERIC)),
-    "<proto package name>.<proto message name>") AS protoResult
+  <namespace>.toMyProtoMessage(STRUCT(word,
+      CAST(word_count AS BIGNUMERIC))) AS protoResult
 FROM
   `bigquery-public-data.samples.shakespeare`
+LIMIT
+  100;
 ```
 
 ## Caveats

--- a/tools/protobuf_export/README.md
+++ b/tools/protobuf_export/README.md
@@ -34,5 +34,14 @@ LIMIT
   100;
 ```
 
+## Required permissions
+The following permissions may be required, depending on usage:
+
+1. bigquery.routines.create - Required to create a user defined function. Required one time for running this procedure.
+2. storage.objects.create - Required to upload pbwrapper.js to GCS. Required one time for running this procedure.
+3. bigquery.tables.export - Required to export data from BigQuery. Required for the user running the query.
+4. storage.objects.get - Required to read pbwrapper.js from GCS. Required for the user running the query.
+
+
 ## Caveats
 1. While the same pbwrapper.js can be used for all .proto files under protos folder, you will still need to create one such function per proto message. That is due to the fact that BigQuery structs are fully typed.

--- a/tools/protobuf_export/README.md
+++ b/tools/protobuf_export/README.md
@@ -15,7 +15,7 @@ type to be exported.
 
 ```
 CREATE FUNCTION
-  <namespace>.toMyProtoMessage(input STRUCT<word STRING,
+  <dataset-id>.toMyProtoMessage(input STRUCT<word STRING,
     wordCount BIGNUMERIC>)
   RETURNS BYTES
   LANGUAGE js OPTIONS ( library=["gs://{YOUR_GCS_BUCKET}/pbwrapper.js"] ) AS r"""
@@ -26,7 +26,7 @@ return pbwrapper.parse(message, input)
  7. Use the created function like so:
 ```
 SELECT
-  <namespace>.toMyProtoMessage(STRUCT(word,
+  <dataset-id>.toMyProtoMessage(STRUCT(word,
       CAST(word_count AS BIGNUMERIC))) AS protoResult
 FROM
   `bigquery-public-data.samples.shakespeare`

--- a/tools/protobuf_export/index.js
+++ b/tools/protobuf_export/index.js
@@ -1,0 +1,67 @@
+const protobufjs = require('protobufjs');
+
+function buildRoot() {  
+  var root;
+  const files = require.context('./protos', true, /\.proto$/)
+  files.keys().forEach((key) => {
+    const file = files(key);
+    const fileContent = file.default;
+    root = protobufjs.parse(fileContent, root).root;
+  });
+  return root;
+}
+
+var chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+
+btoa = function(input) {
+   var str = String(input);
+   for (
+       // initialize result and counter
+       var block, charCode, idx = 0, map = chars, output = [];
+       //   change the mapping table to "="
+       //   check if d has no fractional digits
+       str.charAt(idx | 0) || (map = '=', idx % 1);
+       // "8 - idx % 1 * 8" generates the sequence 2, 4, 6, 8
+       output.push(map.charAt(63 & block >> 8 - idx % 1 * 8))
+   ) {
+       charCode = str.charCodeAt(idx += 3 / 4);
+       if (charCode > 0xFF) {
+           throw Error("'btoa' failed: The string to be encoded contains characters outside of the Latin1 range.");
+       }
+       block = block << 8 | charCode;
+   }
+   return output.join("");
+};
+var root = buildRoot()
+const proto_parser_cache = {};
+function setup(protoMessage){
+	// Check the cache to see if the object already exists
+	const proto_key = protoMessage
+	if (proto_parser_cache[proto_key]) {
+		return proto_parser_cache[proto_key];
+	}
+	
+	// Obtain a message type
+	var messageProto = root.lookupType(protoMessage);
+	// Add it to cache
+	proto_parser_cache[proto_key] = messageProto;
+
+	return proto_parser_cache[proto_key];
+}
+
+function parse(messageProto, input){
+	// Verify the payload if necessary (i.e. when possibly incomplete or invalid)
+	var errMsg = messageProto.verify(input);
+	if (errMsg)
+	   throw Error(errMsg);
+
+	// Create a new message
+	var message = messageProto.create(input);
+
+	// Encode a message to an Uint8Array
+	var buffer = messageProto.encode(message).finish();
+	return btoa(buffer.reduce((arr, byte) => {arr.push(String.fromCharCode(byte)); return arr;}, []).join(""));
+}
+
+module.exports = {setup: setup, parse: parse};
+

--- a/tools/protobuf_export/package.json
+++ b/tools/protobuf_export/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "protobuf-export",
+  "displayName": "protobuf_export",
+  "description": "protobuf_export allows to export protobuf columns from bigquery",
+  "version": "0.0.1",
+  "publisher": "google-cloud",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GoogleCloudPlatform/bigquery-utils.git",
+    "directory": "tools/protobuf_export"
+  },
+  "license": "Apache-2.0",
+  "main": "index.js",
+  "dependencies": {
+    "protobufjs": "7.2.3"
+  },
+  "devDependencies": {
+    "raw-loader": "4.0.2"
+  }
+}

--- a/tools/protobuf_export/protos/dummy.proto
+++ b/tools/protobuf_export/protos/dummy.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package dummypackage;
+
+message DummyMessage {
+  string dummy_field = 1;
+}
+

--- a/tools/protobuf_export/tutorial.md
+++ b/tools/protobuf_export/tutorial.md
@@ -59,7 +59,7 @@ return pbwrapper.parse(message, input)
 ### 2. Use your newly created user-defined function to get protobuf columns
 
 ```sql
-bq query --use_legacy_sql=false 
+bq query --use_legacy_sql=false \
 'SELECT 
   mynamespace.toProto(STRUCT(word), 
     "dummypackage.DummyMessage") 

--- a/tools/protobuf_export/tutorial.md
+++ b/tools/protobuf_export/tutorial.md
@@ -46,14 +46,13 @@ To use pbwrapper.js, click **Next**.
 
 ```sql
 bq query --use_legacy_sql=false \
-'CREATE FUNCTION 
-  mynamespace.toProto(input STRUCT<dummyField STRING>, 
-    protoMessage STRING) 
-  RETURNS BYTES 
-  LANGUAGE js OPTIONS ( library=["gs://{DESTINATION_BUCKET_NAME}/pbwrapper.js"] ) AS r""" 
-let message = pbwrapper.setup(protoMessage); 
-return pbwrapper.parse(message, input) 
- """;' 
+'CREATE FUNCTION
+  mynamespace.toProto(input STRUCT<dummyField STRING>)
+  RETURNS BYTES
+  LANGUAGE js OPTIONS ( library=["gs://{DESTINATION_BUCKET_NAME}/pbwrapper.js"] ) AS r"""
+let message = pbwrapper.setup("dummypackage.DummyMessage");
+return pbwrapper.parse(message, input)
+ """;'
 ```
 
 ### 2. Use your newly created user-defined function to get protobuf columns
@@ -61,12 +60,11 @@ return pbwrapper.parse(message, input)
 ```sql
 bq query --use_legacy_sql=false \
 'SELECT 
-  mynamespace.toProto(STRUCT(word), 
-    "dummypackage.DummyMessage") 
-FROM 
-  bigquery-public-data.samples.shakespeare' 
-LIMIT 
-  100
+  mynamespace.toProto(STRUCT(word))
+FROM
+  bigquery-public-data.samples.shakespeare
+LIMIT
+  100;'
 ```
 
 ## Congratulations 🎉

--- a/tools/protobuf_export/tutorial.md
+++ b/tools/protobuf_export/tutorial.md
@@ -46,13 +46,22 @@ To use pbwrapper.js, click **Next**.
 
 ```bash
 bq query --use_legacy_sql=false \
-'CREATE FUNCTION mynamespace.toProto(input STRUCT<dummyField STRING>, protoMessage STRING) RETURNS BYTES LANGUAGE js OPTIONS ( library=["gs://{DESTINATION_BUCKET_NAME}/pbwrapper.js"] ) AS r""" let message = pbwrapper.setup(protoMessage) return pbwrapper.parse(message, input) """'
+'CREATE OR REPLACE FUNCTION \
+mynamespace.toProto(input STRUCT<dummyField STRING>, protoMessage STRING) \
+RETURNS BYTES \
+LANGUAGE js OPTIONS ( library=["gs://{DESTINATION_BUCKET_NAME}/pbwrapper.js"] ) \
+AS r""" \
+let message = pbwrapper.setup(protoMessage); return \
+pbwrapper.parse(message, input) """'
 ```
 
 ### 2. Use your newly created user-defined function to get protobuf columns
 
 ```bash
-bq query --use_legacy_sql=false \ 'SELECT mynamespace.toProto(STRUCT(word), "dummypackage.DummyMessage") FROM `bigquery-public-data.samples.shakespeare` LIMIT 100'
+bq query --use_legacy_sql=false \
+'SELECT mynamespace.toProto(STRUCT(word), "dummypackage.DummyMessage") \
+FROM `bigquery-public-data.samples.shakespeare`  \
+LIMIT 100'
 ```
 
 ## Congratulations 🎉

--- a/tools/protobuf_export/tutorial.md
+++ b/tools/protobuf_export/tutorial.md
@@ -17,6 +17,7 @@ this example up and running. Follow these steps to run this example:
 ### 1. Install the JavaScript dependencies in the Cloud Shell terminal:
 
 ```bash
+cd tools/protobuf_export
 npm install
 ```
 
@@ -48,7 +49,7 @@ bq query --use_legacy_sql=false \
   LANGUAGE js OPTIONS ( library=["gs://{DESTINATION_BUCKET_NAME}/pbwrapper.js"] ) AS r"""
 let message = pbwrapper.setup(protoMessage)
 return pbwrapper.parse(message, input)
- """;'
+ """'
 ```
 
 ### 2. Use your newly created user-defined function to get protobuf columns
@@ -59,7 +60,8 @@ bq query --use_legacy_sql=false \
   mynamespace.toProto(STRUCT(word),
     "dummypackage.DummyMessage")
 FROM
-  `bigquery-public-data.samples.shakespeare`'
+  `bigquery-public-data.samples.shakespeare`
+LIMIT 100'
 ```
 
 ## Congratulations 🎉

--- a/tools/protobuf_export/tutorial.md
+++ b/tools/protobuf_export/tutorial.md
@@ -14,20 +14,24 @@ Now that you've already downloaded the example to Cloud Shell and you're in the
 example directory, you're ready to run the commands to get
 this example up and running. Follow these steps to run this example:
 
-### 1. Install the JavaScript dependencies in the Cloud Shell terminal:
-
+### 1. Navigate to protobuf_export folder
 ```bash
 cd tools/protobuf_export
+```
+
+### 2. Install the JavaScript dependencies in the Cloud Shell terminal:
+
+```bash
 npm install
 ```
 
-### 2. Generate the pbwrapper.js file by running the following:
+### 3. Generate the pbwrapper.js file by running the following:
 
 ```bash
 npx webpack --config webpack.config.js --stats-error-details
 ```
 
-### 3. Upload pbwrapper.js to GCS:
+### 4. Upload pbwrapper.js to GCS:
 ```bash
 gcloud storage cp dist/pbwrapper.js gs://DESTINATION_BUCKET_NAME/
 ```
@@ -42,26 +46,13 @@ To use pbwrapper.js, click **Next**.
 
 ```bash
 bq query --use_legacy_sql=false \
-'CREATE FUNCTION
-  mynamespace.toProto(input STRUCT<dummyField STRING>,
-    protoMessage STRING)
-  RETURNS BYTES
-  LANGUAGE js OPTIONS ( library=["gs://{DESTINATION_BUCKET_NAME}/pbwrapper.js"] ) AS r"""
-let message = pbwrapper.setup(protoMessage)
-return pbwrapper.parse(message, input)
- """'
+'CREATE FUNCTION mynamespace.toProto(input STRUCT<dummyField STRING>, protoMessage STRING) RETURNS BYTES LANGUAGE js OPTIONS ( library=["gs://{DESTINATION_BUCKET_NAME}/pbwrapper.js"] ) AS r""" let message = pbwrapper.setup(protoMessage) return pbwrapper.parse(message, input) """'
 ```
 
 ### 2. Use your newly created user-defined function to get protobuf columns
 
 ```bash
-bq query --use_legacy_sql=false \
-'SELECT
-  mynamespace.toProto(STRUCT(word),
-    "dummypackage.DummyMessage")
-FROM
-  `bigquery-public-data.samples.shakespeare`
-LIMIT 100'
+bq query --use_legacy_sql=false \ 'SELECT mynamespace.toProto(STRUCT(word), "dummypackage.DummyMessage") FROM `bigquery-public-data.samples.shakespeare` LIMIT 100'
 ```
 
 ## Congratulations 🎉

--- a/tools/protobuf_export/tutorial.md
+++ b/tools/protobuf_export/tutorial.md
@@ -44,26 +44,26 @@ To use pbwrapper.js, click **Next**.
 
 ### 1. Create a user-defined function that uses pbwrapper.js:
 
-```bash
+```sql
 bq query --use_legacy_sql=false \
-'CREATE FUNCTION \
-  mynamespace.toProto(input STRUCT<dummyField STRING>, \
-    protoMessage STRING) \
-  RETURNS BYTES \
-  LANGUAGE js OPTIONS ( library=["gs://{DESTINATION_BUCKET_NAME}/pbwrapper.js"] ) AS r""" \
-let message = pbwrapper.setup(protoMessage); \
-return pbwrapper.parse(message, input) \
+'CREATE FUNCTION 
+  mynamespace.toProto(input STRUCT<dummyField STRING>, 
+    protoMessage STRING) 
+  RETURNS BYTES 
+  LANGUAGE js OPTIONS ( library=["gs://{DESTINATION_BUCKET_NAME}/pbwrapper.js"] ) AS r""" 
+let message = pbwrapper.setup(protoMessage); 
+return pbwrapper.parse(message, input) 
  """;' 
 ```
 
 ### 2. Use your newly created user-defined function to get protobuf columns
 
-```bash
-bq query --use_legacy_sql=false \
-'SELECT \
-  mynamespace.toProto(STRUCT(word), \
-    "dummypackage.DummyMessage") \
-FROM \
+```sql
+bq query --use_legacy_sql=false 
+'SELECT 
+  mynamespace.toProto(STRUCT(word), 
+    "dummypackage.DummyMessage") 
+FROM 
   bigquery-public-data.samples.shakespeare' 
 ```
 

--- a/tools/protobuf_export/tutorial.md
+++ b/tools/protobuf_export/tutorial.md
@@ -47,7 +47,7 @@ To use pbwrapper.js, click **Next**.
 ```sql
 bq query --use_legacy_sql=false \
 'CREATE FUNCTION
-  mynamespace.toMyProtoMessage(input STRUCT<dummyField STRING>)
+  my-dataset-id.toMyProtoMessage(input STRUCT<dummyField STRING>)
   RETURNS BYTES
   LANGUAGE js OPTIONS ( library=["gs://{DESTINATION_BUCKET_NAME}/pbwrapper.js"] ) AS r"""
 let message = pbwrapper.setup("dummypackage.DummyMessage");
@@ -60,7 +60,7 @@ return pbwrapper.parse(message, input)
 ```sql
 bq query --use_legacy_sql=false \
 'SELECT
-  mynamespace.toMyProtoMessage(STRUCT(word))
+  my-dataset-id.toMyProtoMessage(STRUCT(word))
 FROM
   bigquery-public-data.samples.shakespeare
 LIMIT

--- a/tools/protobuf_export/tutorial.md
+++ b/tools/protobuf_export/tutorial.md
@@ -1,0 +1,67 @@
+# Get Started with Protobuf Export!
+
+## Let's get started!
+
+This guide will show you how to export protobuf columns.
+
+**Time to complete**: About 10-15 minutes
+
+Click the **Start** button to move to the next step.
+
+## Run the following to create pbwrapper.js.
+
+Now that you've already downloaded the example to Cloud Shell and you're in the
+example directory, you're ready to run the commands to get
+this example up and running. Follow these steps to run this example:
+
+### 1. Install the JavaScript dependencies in the Cloud Shell terminal:
+
+```bash
+npm install
+```
+
+### 2. Generate the pbwrapper.js file by running the following:
+
+```bash
+npx webpack --config webpack.config.js --stats-error-details
+```
+
+### 3. Upload pbwrapper.js to GCS:
+```bash
+gcloud storage cp dist/pbwrapper.js gs://DESTINATION_BUCKET_NAME/
+```
+
+Congratulations, you successfully uploaded dist/pbwrapper.js to GCS!
+
+To use pbwrapper.js, click **Next**.
+
+## Use pbwrapper.js to export protobuf columns
+
+### 1. Create a user-defined function that uses pbwrapper.js:
+
+```bash
+bq query --use_legacy_sql=false \
+'CREATE FUNCTION
+  mynamespace.toProto(input STRUCT<dummyField STRING>,
+    protoMessage STRING)
+  RETURNS BYTES
+  LANGUAGE js OPTIONS ( library=["gs://{DESTINATION_BUCKET_NAME}/pbwrapper.js"] ) AS r"""
+let message = pbwrapper.setup(protoMessage)
+return pbwrapper.parse(message, input)
+ """;'
+```
+
+### 2. Use your newly created user-defined function to get protobuf columns
+
+```bash
+bq query --use_legacy_sql=false \
+'SELECT
+  mynamespace.toProto(STRUCT(word),
+    "dummypackage.DummyMessage")
+FROM
+  `bigquery-public-data.samples.shakespeare`'
+```
+
+## Congratulations 🎉
+
+You have successfully queried a protobuf column from BigQuery!

--- a/tools/protobuf_export/tutorial.md
+++ b/tools/protobuf_export/tutorial.md
@@ -46,25 +46,25 @@ To use pbwrapper.js, click **Next**.
 
 ```bash
 bq query --use_legacy_sql=false \
-'CREATE FUNCTION
-  mynamespace.toProto(input STRUCT<dummyField STRING>,
-    protoMessage STRING)
-  RETURNS BYTES
-  LANGUAGE js OPTIONS ( library=["gs://{DESTINATION_BUCKET_NAME}/pbwrapper.js"] ) AS r"""
-let message = pbwrapper.setup(protoMessage)
-return pbwrapper.parse(message, input)
- """;'
+'CREATE FUNCTION 
+  mynamespace.toProto(input STRUCT<dummyField STRING>, 
+    protoMessage STRING) 
+  RETURNS BYTES 
+  LANGUAGE js OPTIONS ( library=["gs://{DESTINATION_BUCKET_NAME}/pbwrapper.js"] ) AS r""" 
+let message = pbwrapper.setup(protoMessage);
+return pbwrapper.parse(message, input) 
+ """;' 
 ```
 
 ### 2. Use your newly created user-defined function to get protobuf columns
 
 ```bash
 bq query --use_legacy_sql=false \
-'SELECT
-  mynamespace.toProto(STRUCT(word),
-    "dummypackage.DummyMessage")
-FROM
-  bigquery-public-data.samples.shakespeare'
+'SELECT 
+  mynamespace.toProto(STRUCT(word), 
+    "dummypackage.DummyMessage") 
+FROM 
+  bigquery-public-data.samples.shakespeare' 
 ```
 
 ## Congratulations 🎉

--- a/tools/protobuf_export/tutorial.md
+++ b/tools/protobuf_export/tutorial.md
@@ -47,7 +47,7 @@ To use pbwrapper.js, click **Next**.
 ```sql
 bq query --use_legacy_sql=false \
 'CREATE FUNCTION
-  mynamespace.toProto(input STRUCT<dummyField STRING>)
+  mynamespace.toMyProtoMessage(input STRUCT<dummyField STRING>)
   RETURNS BYTES
   LANGUAGE js OPTIONS ( library=["gs://{DESTINATION_BUCKET_NAME}/pbwrapper.js"] ) AS r"""
 let message = pbwrapper.setup("dummypackage.DummyMessage");
@@ -59,8 +59,8 @@ return pbwrapper.parse(message, input)
 
 ```sql
 bq query --use_legacy_sql=false \
-'SELECT 
-  mynamespace.toProto(STRUCT(word))
+'SELECT
+  mynamespace.toMyProtoMessage(STRUCT(word))
 FROM
   bigquery-public-data.samples.shakespeare
 LIMIT

--- a/tools/protobuf_export/tutorial.md
+++ b/tools/protobuf_export/tutorial.md
@@ -36,7 +36,7 @@ npx webpack --config webpack.config.js --stats-error-details
 gcloud storage cp dist/pbwrapper.js gs://DESTINATION_BUCKET_NAME/
 ```
 
-Congratulations, you successfully uploaded dist/pbwrapper.js to GCS!
+Congratulations, you successfully uploaded pbwrapper.js to GCS!
 
 To use pbwrapper.js, click **Next**.
 
@@ -46,22 +46,25 @@ To use pbwrapper.js, click **Next**.
 
 ```bash
 bq query --use_legacy_sql=false \
-'CREATE OR REPLACE FUNCTION \
-mynamespace.toProto(input STRUCT<dummyField STRING>, protoMessage STRING) \
-RETURNS BYTES \
-LANGUAGE js OPTIONS ( library=["gs://{DESTINATION_BUCKET_NAME}/pbwrapper.js"] ) \
-AS r""" \
-let message = pbwrapper.setup(protoMessage); return \
-pbwrapper.parse(message, input) """'
+'CREATE FUNCTION
+  mynamespace.toProto(input STRUCT<dummyField STRING>,
+    protoMessage STRING)
+  RETURNS BYTES
+  LANGUAGE js OPTIONS ( library=["gs://{DESTINATION_BUCKET_NAME}/pbwrapper.js"] ) AS r"""
+let message = pbwrapper.setup(protoMessage)
+return pbwrapper.parse(message, input)
+ """;'
 ```
 
 ### 2. Use your newly created user-defined function to get protobuf columns
 
 ```bash
 bq query --use_legacy_sql=false \
-'SELECT mynamespace.toProto(STRUCT(word), "dummypackage.DummyMessage") \
-FROM `bigquery-public-data.samples.shakespeare`  \
-LIMIT 100'
+'SELECT
+  mynamespace.toProto(STRUCT(word),
+    "dummypackage.DummyMessage")
+FROM
+  bigquery-public-data.samples.shakespeare'
 ```
 
 ## Congratulations 🎉

--- a/tools/protobuf_export/tutorial.md
+++ b/tools/protobuf_export/tutorial.md
@@ -65,6 +65,8 @@ bq query --use_legacy_sql=false \
     "dummypackage.DummyMessage") 
 FROM 
   bigquery-public-data.samples.shakespeare' 
+LIMIT 
+  100
 ```
 
 ## Congratulations 🎉

--- a/tools/protobuf_export/tutorial.md
+++ b/tools/protobuf_export/tutorial.md
@@ -46,13 +46,13 @@ To use pbwrapper.js, click **Next**.
 
 ```bash
 bq query --use_legacy_sql=false \
-'CREATE FUNCTION 
-  mynamespace.toProto(input STRUCT<dummyField STRING>, 
-    protoMessage STRING) 
-  RETURNS BYTES 
-  LANGUAGE js OPTIONS ( library=["gs://{DESTINATION_BUCKET_NAME}/pbwrapper.js"] ) AS r""" 
-let message = pbwrapper.setup(protoMessage);
-return pbwrapper.parse(message, input) 
+'CREATE FUNCTION \
+  mynamespace.toProto(input STRUCT<dummyField STRING>, \
+    protoMessage STRING) \
+  RETURNS BYTES \
+  LANGUAGE js OPTIONS ( library=["gs://{DESTINATION_BUCKET_NAME}/pbwrapper.js"] ) AS r""" \
+let message = pbwrapper.setup(protoMessage); \
+return pbwrapper.parse(message, input) \
  """;' 
 ```
 
@@ -60,10 +60,10 @@ return pbwrapper.parse(message, input)
 
 ```bash
 bq query --use_legacy_sql=false \
-'SELECT 
-  mynamespace.toProto(STRUCT(word), 
-    "dummypackage.DummyMessage") 
-FROM 
+'SELECT \
+  mynamespace.toProto(STRUCT(word), \
+    "dummypackage.DummyMessage") \
+FROM \
   bigquery-public-data.samples.shakespeare' 
 ```
 

--- a/tools/protobuf_export/webpack.config.js
+++ b/tools/protobuf_export/webpack.config.js
@@ -1,0 +1,20 @@
+const path = require('path');
+
+module.exports = {
+    module: {
+        rules: [{
+            test: /\.proto$/,
+            use: [{
+                loader: 'raw-loader',
+            }, ],
+        }, ],
+    },
+    entry: './index.js',
+    output: {
+        path: path.resolve(__dirname, 'dist'),
+        filename: 'pbwrapper.js',
+        library: "pbwrapper",
+    },
+    mode: "production",
+};
+


### PR DESCRIPTION
In Order to support Protobuf export from BigQuery, a process has to be followed, as this is not supported by default.
The process is defined for anyone wishing to export a protobuf column to use.