### PR TITLE
[UDF] Add UDF for emulating snowflake split_part

### DIFF
--- a/udfs/community/README.md
+++ b/udfs/community/README.md
@@ -94,6 +94,7 @@ SELECT bqutil.fn.int(1.684)
 * [cw_setbit](#cw_setbitbits-int64-index-int64)
 * [cw_signed_leftshift_128bit](#cw_signed_leftshift_128bitvalue-bignumeric-n-bignumeric)
 * [cw_signed_rightshift_128bit](#cw_signed_rightshift_128bitvalue-bignumeric-n-bignumeric)
+* [cw_split_part_delimstr_idx](#cw_split_part_delimstr_idxvalue-string-delimiter-string-part-int64)
 * [cw_stringify_interval](#cw_stringify_intervalx-int64)
 * [cw_strtok](#cw_strtoktext-string-delim-string)
 * [cw_substrb](#cw_substrbstr-string-startpos-int64-extent-int64)
@@ -936,6 +937,21 @@ Performs a signed shift right on BIGNUMERIC as if it was a 128 bit integer.
 - -1
 - -1
 ```
+
+### [cw_split_part_delimstr_idx(value STRING, delimiter STRING, part INT64)](cw_split_part_delimstr_idx.sqlx)
+Extract a part from a string value delimited by a delimiter string.
+Indexing start from 1. Negative offsets count from the end.
+
+```SQL
+- SELECT bqutil.fn.cw_split_part_delimstr_idx('foo bar baz', ' ', 3)
+- SELECT bqutil.fn.cw_split_part_delimstr_idx('foo bar baz', ' ', -3)
+- SELECT bqutil.fn.cw_split_part_delimstr_idx('foo bar baz', ' ', 4)
+
+- bar
+- foo
+- NULL
+```
+
 
 ### [cw_stringify_interval(x INT64)](cw_stringify_interval.sqlx)
 Formats the interval as 'day hour:minute:second

--- a/udfs/community/cw_split_part_delimstr_idx.sqlx
+++ b/udfs/community/cw_split_part_delimstr_idx.sqlx
@@ -1,0 +1,29 @@
+config { hasOutput: true }
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+CREATE OR REPLACE FUNCTION ${self()}(value STRING, delimiter STRING, part INT64)
+  RETURNS STRING
+  OPTIONS(
+    description="""Extract the Nth part of a string (index starts at 1). Similar to snowflake SPLIT_PART"""
+  )
+  AS (
+     (WITH t AS (SELECT split(value, delimiter) AS s),
+           n AS (SELECT CASE WHEN part = 0 THEN 1
+                             WHEN part < 0 THEN ARRAY_LENGTH(s) + part + 1
+                             ELSE part END AS i FROM t)
+        SELECT t.s[SAFE_ORDINAL(n.i)] FROM t, n)
+);

--- a/udfs/community/test_cases.js
+++ b/udfs/community/test_cases.js
@@ -3009,7 +3009,96 @@ generate_udf_test("cw_period_rdiff", [
         expected_output: `NULL`
     },
 ]);
-
+generate_udf_test("cw_split_part_delimstr_idx", [
+  {
+    inputs: [
+      `"foo bar baz"`,
+      `" "`,
+      `1`
+    ],
+    expected_output: `"foo"`,
+  },
+  {
+    inputs: [
+      `"foo bar baz"`,
+      `" "`,
+      `2`
+    ],
+    expected_output: `"bar"`,
+  },
+  {
+    inputs: [
+      `"foo bar baz"`,
+      `" "`,
+      `0`
+    ],
+    expected_output: `"foo"`,
+  },
+  {
+    inputs: [
+      `"foo bar baz"`,
+      `" "`,
+      `-1`
+    ],
+    expected_output: `"baz"`,
+  },
+  {
+    inputs: [
+      `"foo bar baz"`,
+      `" "`,
+      `4`
+    ],
+    expected_output: `NULL`,
+  },
+  {
+    inputs: [
+      `"foo bar baz"`,
+      `" "`,
+      `-3`
+    ],
+    expected_output: `"foo"`,
+  },
+  {
+    inputs: [
+      `"foo bar baz"`,
+      `" "`,
+      `-4`
+    ],
+    expected_output: `NULL`,
+  },
+  {
+    inputs: [
+      `"foo  bar baz"`,
+      `"  "`,
+      `2`
+    ],
+    expected_output: `"bar baz"`,
+  },
+  {
+    inputs: [
+      `NULL`,
+      `" "`,
+      `1`
+    ],
+    expected_output: `NULL`,
+  },
+  {
+    inputs: [
+      `"foo bar baz"`,
+      `NULL`,
+      `1`
+    ],
+    expected_output: `NULL`,
+  },
+  {
+    inputs: [
+      `"foo bar baz"`,
+      `" "`,
+      `NULL`
+    ],
+    expected_output: `NULL`,
+  }
+]);
 generate_udf_test("sure_nonnull", [
   {
     inputs: [


### PR DESCRIPTION
This adds a function for emulating snowflake split_part. This function has the following semantics:

- The part index is 1-based
- However, index 0 is treated as 1
- Negative numbers are interpreted as indexes from the end of the string

It will help customers migrate from Snowflake to BigQuery.