### PR TITLE
[UDF] Improve emulation of Snowflake SPLIT_PART

### DIFF
--- a/udfs/community/cw_split_part_delimstr_idx.sqlx
+++ b/udfs/community/cw_split_part_delimstr_idx.sqlx
@@ -27,5 +27,6 @@ CREATE OR REPLACE FUNCTION ${self()}(value STRING, delimiter STRING, part INT64)
            n AS (SELECT CASE WHEN part = 0 THEN 1
                              WHEN part < 0 THEN ARRAY_LENGTH(s) + part + 1
                              ELSE part END AS i FROM t)
-        SELECT COALESCE(t.s[SAFE_ORDINAL(n.i)], '') FROM t, n)
+        SELECT CASE WHEN n.i < 1 OR n.i > ARRAY_LENGTH(t.s) THEN ''
+	            ELSE t.s[ORDINAL(n.i)] END FROM t, n)
 );

--- a/udfs/community/cw_split_part_delimstr_idx.sqlx
+++ b/udfs/community/cw_split_part_delimstr_idx.sqlx
@@ -21,9 +21,11 @@ CREATE OR REPLACE FUNCTION ${self()}(value STRING, delimiter STRING, part INT64)
     description="""Extract the Nth part of a string (index starts at 1). Similar to snowflake SPLIT_PART"""
   )
   AS (
-     (WITH t AS (SELECT split(value, delimiter) AS s),
+     (WITH t AS (SELECT CASE WHEN delimiter = ''
+                             THEN array[value]
+                             ELSE split(value, delimiter) END AS s),
            n AS (SELECT CASE WHEN part = 0 THEN 1
                              WHEN part < 0 THEN ARRAY_LENGTH(s) + part + 1
                              ELSE part END AS i FROM t)
-        SELECT t.s[SAFE_ORDINAL(n.i)] FROM t, n)
+        SELECT COALESCE(t.s[SAFE_ORDINAL(n.i)], '') FROM t, n)
 );

--- a/udfs/community/test_cases.js
+++ b/udfs/community/test_cases.js
@@ -3096,7 +3096,7 @@ generate_udf_test("cw_split_part_delimstr_idx", [
       `" "`,
       `1`
     ],
-    expected_output: `NULL`,
+    expected_output: `CAST(NULL AS STRING)`,
   },
   {
     inputs: [
@@ -3104,7 +3104,7 @@ generate_udf_test("cw_split_part_delimstr_idx", [
       `NULL`,
       `1`
     ],
-    expected_output: `NULL`,
+    expected_output: `CAST(NULL AS STRING)`,
   },
   {
     inputs: [
@@ -3112,7 +3112,7 @@ generate_udf_test("cw_split_part_delimstr_idx", [
       `" "`,
       `NULL`
     ],
-    expected_output: `NULL`,
+    expected_output: `CAST(NULL AS STRING)`,
   }
 ]);
 generate_udf_test("sure_nonnull", [

--- a/udfs/community/test_cases.js
+++ b/udfs/community/test_cases.js
@@ -3048,7 +3048,7 @@ generate_udf_test("cw_split_part_delimstr_idx", [
       `" "`,
       `4`
     ],
-    expected_output: `NULL`,
+    expected_output: `""`,
   },
   {
     inputs: [
@@ -3064,7 +3064,7 @@ generate_udf_test("cw_split_part_delimstr_idx", [
       `" "`,
       `-4`
     ],
-    expected_output: `NULL`,
+    expected_output: `""`,
   },
   {
     inputs: [
@@ -3073,6 +3073,22 @@ generate_udf_test("cw_split_part_delimstr_idx", [
       `2`
     ],
     expected_output: `"bar baz"`,
+  },
+  {
+    inputs: [
+      `"foo bar baz"`,
+      `""`,
+      `1`
+    ],
+    expected_output: `"foo bar baz"`,
+  },
+  {
+    inputs: [
+      `"foo bar baz"`,
+      `""`,
+      `2`
+    ],
+    expected_output: `""`,
   },
   {
     inputs: [

--- a/udfs/community/test_cases.js
+++ b/udfs/community/test_cases.js
@@ -3048,7 +3048,7 @@ generate_udf_test("cw_split_part_delimstr_idx", [
       `" "`,
       `4`
     ],
-    expected_output: `""`,
+    expected_output: `CAST("" AS STRING)`,
   },
   {
     inputs: [
@@ -3064,7 +3064,7 @@ generate_udf_test("cw_split_part_delimstr_idx", [
       `" "`,
       `-4`
     ],
-    expected_output: `""`,
+    expected_output: `CAST("" AS STRING)`,
   },
   {
     inputs: [
@@ -3088,7 +3088,7 @@ generate_udf_test("cw_split_part_delimstr_idx", [
       `""`,
       `2`
     ],
-    expected_output: `""`,
+    expected_output: `CAST("" AS STRING)`,
   },
   {
     inputs: [

--- a/udfs/community/test_cases.js
+++ b/udfs/community/test_cases.js
@@ -3048,7 +3048,7 @@ generate_udf_test("cw_split_part_delimstr_idx", [
       `" "`,
       `4`
     ],
-    expected_output: `CAST("" AS STRING)`,
+    expected_output: `""`,
   },
   {
     inputs: [
@@ -3064,7 +3064,7 @@ generate_udf_test("cw_split_part_delimstr_idx", [
       `" "`,
       `-4`
     ],
-    expected_output: `CAST("" AS STRING)`,
+    expected_output: `""`,
   },
   {
     inputs: [
@@ -3088,7 +3088,7 @@ generate_udf_test("cw_split_part_delimstr_idx", [
       `""`,
       `2`
     ],
-    expected_output: `CAST("" AS STRING)`,
+    expected_output: `""`,
   },
   {
     inputs: [
@@ -3096,7 +3096,7 @@ generate_udf_test("cw_split_part_delimstr_idx", [
       `" "`,
       `1`
     ],
-    expected_output: `CAST(NULL AS STRING)`,
+    expected_output: `NULL`,
   },
   {
     inputs: [
@@ -3104,7 +3104,7 @@ generate_udf_test("cw_split_part_delimstr_idx", [
       `NULL`,
       `1`
     ],
-    expected_output: `CAST(NULL AS STRING)`,
+    expected_output: `NULL`,
   },
   {
     inputs: [
@@ -3112,7 +3112,7 @@ generate_udf_test("cw_split_part_delimstr_idx", [
       `" "`,
       `NULL`
     ],
-    expected_output: `CAST(NULL AS STRING)`,
+    expected_output: `NULL`,
   }
 ]);
 generate_udf_test("sure_nonnull", [


### PR DESCRIPTION
- when there's an empty delimiter, the first part is the input string (don't split into individual characters)
- when there's an out-of-bounds value, the return value is an empty string ("") rather than NULL