### PR TITLE
Fixes issue in `regex_substr_4` function when regex has groupings.

### DIFF
--- a/udfs/community/README.md
+++ b/udfs/community/README.md
@@ -856,10 +856,14 @@ Takes input haystack string, needle string, position and occurence. It returns n
 SELECT bqutil.fn.cw_regexp_substr_4('TestStr123456', 'Test', 1, 1);
 SELECT bqutil.fn.cw_regexp_substr_4('TestStr123456Test', 'Test', 1, 2);
 SELECT bqutil.fn.cw_regexp_substr_4('TestStr123456Test', 'Test', 1, 3);
+SELECT bqutil.fn.cw_regexp_substr_4('Test123Str123Test', '(Test|Str)123', 1, 1);
+SELECT bqutil.fn.cw_regexp_substr_4('Test123Str123Test', '(Test|Str)123', 1, 2);
 
 Test
 Test
 null
+Test123
+Str123
 ```
 
 ### [cw_regexp_substr_5(h STRING, n STRING, p INT64, o INT64, mode STRING)](cw_regexp_substr_5.sqlx)

--- a/udfs/community/cw_regexp_substr_4.sqlx
+++ b/udfs/community/cw_regexp_substr_4.sqlx
@@ -15,8 +15,8 @@ config { hasOutput: true }
  * limitations under the License.
  */
 
-/* Implements regexp_substr/4 (haystack, needle, position, occurence) */
+/* Implements regexp_substr/4 (haystack, needle, position, occurence). Similar to Teradata's REGEXP_SUBSTR(haystack, needle, position, occurence) function. */
 CREATE OR REPLACE FUNCTION ${self()}(h STRING, n STRING, p INT64, o INT64) RETURNS STRING AS
 (
-    regexp_extract_all(substr(h, p), n)[safe_ordinal(o)]
+    ${ref("cw_regexp_extract_all")}(substr(h, p), n)[safe_ordinal(o)]
 );

--- a/udfs/community/cw_regexp_substr_4.sqlx
+++ b/udfs/community/cw_regexp_substr_4.sqlx
@@ -16,7 +16,12 @@ config { hasOutput: true }
  */
 
 /* Implements regexp_substr/4 (haystack, needle, position, occurence). Similar to Teradata's REGEXP_SUBSTR(haystack, needle, position, occurence) function. */
-CREATE OR REPLACE FUNCTION ${self()}(h STRING, n STRING, p INT64, o INT64) RETURNS STRING AS
+CREATE OR REPLACE FUNCTION ${self()}(h STRING, n STRING, p INT64, o INT64)
+RETURNS STRING
+OPTIONS (
+    description="""Implements regexp_substr/4 (haystack, needle, position, occurence).
+Similar to Teradata's REGEXP_SUBSTR(haystack, needle, position, occurence) function."""
+) AS
 (
     ${ref("cw_regexp_extract_all")}(substr(h, p), n)[safe_ordinal(o)]
 );

--- a/udfs/community/test_cases.js
+++ b/udfs/community/test_cases.js
@@ -1372,6 +1372,24 @@ generate_udf_test("cw_regexp_substr_4", [
         ],
         expected_output: `"123"`
     },
+    {
+        inputs: [
+            `"Test123Str123456"`,
+            `"(Test|Str)123"`,
+            `CAST(1 AS INT64)`,
+            `CAST(1 AS INT64)`
+        ],
+        expected_output: `"Test123"`
+    },
+    {
+        inputs: [
+            `"Test123Str123456"`,
+            `"(Test|Str)123"`,
+            `CAST(1 AS INT64)`,
+            `CAST(2 AS INT64)`
+        ],
+        expected_output: `"Str123"`
+    },
 ]);
 generate_udf_test("cw_regexp_substr_generic", [
     {


### PR DESCRIPTION
Like `regex_substr_5`, after successful regex match `regex_substr_4` should return entire matched substring and not just the first group that is matched. With this fix, UDF exhibits the behavior that is consistent with other regex UDFs such as `cw_regex_extract`, `cw_regex_substr_5` etc.