### PR TITLE
[UDF] Fix `cw_regexp_instr_3` assumption that `start` argument is 0-based.

### DIFF
--- a/udfs/community/cw_regexp_instr_3.sqlx
+++ b/udfs/community/cw_regexp_instr_3.sqlx
@@ -16,8 +16,8 @@ config { hasOutput: true }
  */
 
 CREATE OR REPLACE FUNCTION ${self()}(haystack STRING, needle STRING, start INT64) RETURNS INT64 AS (
-  CASE WHEN REGEXP_CONTAINS(substr(haystack, start), needle) THEN
-    LENGTH(REGEXP_REPLACE(substr(haystack, start), CONCAT('(.*?)', needle, '(.*)'), '\\1')) + 1 + start
+  CASE WHEN REGEXP_CONTAINS(substr(haystack, GREATEST(start, 1)), needle) THEN
+    LENGTH(REGEXP_REPLACE(substr(haystack, GREATEST(start, 1)), CONCAT('(.*?)', needle, '(.*)'), '\\1')) + GREATEST(start, 1)
   WHEN needle IS NULL OR haystack IS NULL or start IS NULL THEN
     NULL
   ELSE 0

--- a/udfs/community/test_cases.js
+++ b/udfs/community/test_cases.js
@@ -1510,9 +1510,57 @@ generate_udf_test("cw_regexp_instr_3", [
         inputs: [
             `"TestStr123456"`,
             `"Str"`,
+            `CAST(1 AS INT64)`
+        ],
+        expected_output: `CAST(5 AS INT64)`
+    },
+    {
+        inputs: [
+            `"TestStr123456"`,
+            `"Str"`,
+            `CAST(-1 AS INT64)`
+        ],
+        expected_output: `CAST(5 AS INT64)`
+    },
+    {
+        inputs: [
+            `"TestStr123456"`,
+            `"Str"`,
             `CAST(6 AS INT64)`
         ],
         expected_output: `CAST(0 AS INT64)`
+    },
+    {
+        inputs: [
+            `"TestStr123456"`,
+            `"7"`,
+            `CAST(1 AS INT64)`
+        ],
+        expected_output: `CAST(0 AS INT64)`
+    },
+    {
+        inputs: [
+            `NULL`,
+            `"Str"`,
+            `CAST(6 AS INT64)`
+        ],
+        expected_output: `NULL`
+    },
+    {
+        inputs: [
+            `"TestStr123456"`,
+            `NULL`,
+            `CAST(6 AS INT64)`
+        ],
+        expected_output: `NULL`
+    },
+    {
+        inputs: [
+            `"TestStr123456"`,
+            `"Str"`,
+            `NULL`
+        ],
+        expected_output: `NULL`
     },
 ]);
 generate_udf_test("cw_regexp_instr_4", [


### PR DESCRIPTION
The `start` argument in `cw_regexp_instr_3`  is 1-based, we allow for `start <= 0` and consider it as `1` for compatiblity.