### PR TITLE
[UDF] Add strtok function for teradata emulation

### DIFF
--- a/udfs/community/cw_td_strtok.sqlx
+++ b/udfs/community/cw_td_strtok.sqlx
@@ -1,0 +1,40 @@
+config { hasOutput: true }
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+CREATE OR REPLACE FUNCTION ${self()}(input STRING, delim STRING, num INT64)
+  RETURNS STRING
+  LANGUAGE js
+  AS '''
+  var start = 0;
+  var end = 0;
+  for (var i = 0; i < num; i++) {
+    // strtok first removes all preceding delimiters
+    for (start = end; start < input.length; start++) {
+      if (delim.indexOf(input.charAt(start)) < 0) {
+	break;
+      }
+    }
+    for (end = start; end < input.length; end++) {
+      if (delim.indexOf(input.charAt(end)) >= 0) {
+	break;
+      }
+    }
+  }
+  if (start == input.length && num > 1) {
+    return null;
+  }
+  return input.substring(start, end);
+''';

--- a/udfs/community/test_cases.js
+++ b/udfs/community/test_cases.js
@@ -2458,6 +2458,91 @@ generate_udf_test("cw_strtok", [
                            STRUCT(CAST(2 AS INT64) AS tokennumber, "1" AS token)])`
     },
 ]);
+generate_udf_test("cw_td_strtok", [
+    {
+        inputs: [
+          `"foo;bar;baz"`,
+          `";"`,
+          `1`,
+        ],
+        expected_output: `"foo"`
+    },
+    {
+        inputs: [
+          `"foo;bar;baz"`,
+          `";"`,
+          `3`,
+        ],
+        expected_output: `"baz"`
+    },
+    {
+        inputs: [
+          `";foo;bar;baz"`,
+          `";"`,
+          `1`,
+        ],
+        expected_output: `"foo"`
+    },
+    {
+        inputs: [
+          `";foo;;bar;baz"`,
+          `";"`,
+          `2`,
+        ],
+        expected_output: `"bar"`
+    },
+
+    {
+        inputs: [
+          `";foo;;"`,
+          `";"`,
+          `2`,
+        ],
+        expected_output: `null`
+    },
+    {
+        inputs: [
+          `";;;"`,
+          `";"`,
+          `1`
+        ],
+        expected_output: `""`
+    },
+    {
+        inputs: [
+          `";;;"`,
+          `";"`,
+          `2`
+        ],
+        expected_output: `null`
+    },
+    {
+        inputs: [
+          `"a-b;c"`,
+          `";-"`,
+          `3`
+        ],
+        expected_output: `"c"`
+    },
+    {
+        inputs: [
+          `"aa"`,
+          `";"`,
+          `1'`
+        ],
+        expected_output: `"aa"`
+    },
+    {
+        inputs: [
+          `"aa"`,
+          `";"`,
+          `2`
+        ],
+        expected_output: `null`
+    },
+]);
+
+
 generate_udf_test("cw_regexp_split", [
     {
         inputs: [

--- a/udfs/community/test_cases.js
+++ b/udfs/community/test_cases.js
@@ -2528,7 +2528,7 @@ generate_udf_test("cw_td_strtok", [
         inputs: [
           `"aa"`,
           `";"`,
-          `1'`
+          `1`
         ],
         expected_output: `"aa"`
     },


### PR DESCRIPTION
STRTOK in Teradata is a bit special (or rather, it's similar to libc's strtok, and that's a bit special):

- ignores leading delimiters
- ignores duplicate delimiters
- returns NULL for out-of-band fields
- except if the whole string consists of delimiters, and you want the first token, in which case it returns an empty string