### PR TITLE
Update typeof. Support of single quoted JSON

### DIFF
--- a/udfs/community/typeof.sqlx
+++ b/udfs/community/typeof.sqlx
@@ -23,7 +23,7 @@ AS ( (
     SELECT
       CASE
       -- Process NUMERIC, DATE, DATETIME, TIME, TIMESTAMP,
-        WHEN REGEXP_CONTAINS(literal, r'^[A-Z]+ "') THEN REGEXP_EXTRACT(literal, r'^([A-Z]+) "')
+        WHEN REGEXP_CONTAINS(literal, r'^[A-Z]+ ("|\')') THEN REGEXP_EXTRACT(literal, r'^([A-Z]+) (?:"|\')')
         WHEN REGEXP_CONTAINS(literal, r'^-?[0-9]*$') THEN 'INT64'
         WHEN REGEXP_CONTAINS(literal, r'^(-?[0-9]+[.e].*|CAST\("([^"]*)" AS FLOAT64\))$') THEN 'FLOAT64'
         WHEN literal IN ('true', 'false') THEN 'BOOL'


### PR DESCRIPTION
This fix is adding support for single-quoted JSON.
Currently, it works only with double-quoted JSON. There is no way to check JSON containing strings, dictionaries and lists.

This works:
SELECT typeof(JSON "null");
SELECT typeof(JSON "100");

This won't work:
SELECT typeof(JSON '"text"');
SELECT typeof(JSON '{"gate": "A4", "flight_number": 2005}');



Fixed EXAMPLE:
CREATE temp FUNCTION typeof (input ANY TYPE)
AS ( (
    SELECT
      CASE
      -- Process NUMERIC, DATE, DATETIME, TIME, TIMESTAMP,
        WHEN REGEXP_CONTAINS(literal, r'^[A-Z]+ ("|\')') THEN REGEXP_EXTRACT(literal, r'^([A-Z]+) (?:"|\')') --modified regexp
        WHEN REGEXP_CONTAINS(literal, r'^-?[0-9]*$') THEN 'INT64'
        WHEN REGEXP_CONTAINS(literal, r'^(-?[0-9]+[.e].*|CAST\("([^"]*)" AS FLOAT64\))$') THEN 'FLOAT64'
        WHEN literal IN ('true', 'false') THEN 'BOOL'
        WHEN literal LIKE '"%' OR literal LIKE "'%" THEN 'STRING'
        WHEN literal LIKE 'b"%' THEN 'BYTES'
        WHEN literal LIKE '[%' THEN 'ARRAY'
        WHEN REGEXP_CONTAINS(literal, r'^(STRUCT)?\(') THEN 'STRUCT'
        WHEN literal LIKE 'ST_%' THEN 'GEOGRAPHY'
        WHEN literal = 'NULL' THEN 'NULL'
      ELSE
      'UNKNOWN'
    END
    FROM
      UNNEST([FORMAT('%T', input)]) AS literal));


SELECT typeof(JSON '"text"');
SELECT typeof(JSON '{"gate": "A4", "flight_number": 2005}');