### PR TITLE
Adding studentt_cdf UDF

### DIFF
--- a/udfs/community/README.md
+++ b/udfs/community/README.md
@@ -2367,7 +2367,7 @@ Returns the value of x in the cdf of the Student's T distribution with dof degre
 Sample Query:
 
 ```SQL
-SELECT `bqutils.fn.studentt_cdf`(1.0, 2) as studentt_cdf;
+SELECT `bqutils.fn.studentt_cdf`(1.0, 2.0) as studentt_cdf;
 ```
 
 Results:

--- a/udfs/community/README.md
+++ b/udfs/community/README.md
@@ -162,6 +162,7 @@ SELECT bqutil.fn.int(1.684)
 * [random_int](#random_intmin-any-type-max-any-type)
 * [random_string](#random_stringlength-int64)
 * [random_value](#random_valuearr-any-type)
+* [studentt_cdf](#studentt_cdfx-float64-dof-int64)
 * [sure_cond](#sure_cond)
 * [sure_like](#sure_like)
 * [sure_nonnull](#sure_nonnull)
@@ -2356,3 +2357,21 @@ Results:
 | Row	| normal_cdf |
 |-----|-------------------|
 | 1	| 0.3820885778110474 |
+
+---
+
+### [studentt_cdf(x FLOAT64, dof INT64)](studentt_cdf.sqlx)
+
+Returns the value of x in the cdf of the Student's T distribution with dof degrees of freedom.
+
+Sample Query:
+
+```SQL
+SELECT `bqutils.fn.studentt_cdf`(1.0, 2) as studentt_cdf;
+```
+
+Results:
+
+| Row | studentt_cdf      |
+| --- | ----------------- |
+| 1   | 0.788675134594813 |

--- a/udfs/community/README.md
+++ b/udfs/community/README.md
@@ -162,7 +162,7 @@ SELECT bqutil.fn.int(1.684)
 * [random_int](#random_intmin-any-type-max-any-type)
 * [random_string](#random_stringlength-int64)
 * [random_value](#random_valuearr-any-type)
-* [studentt_cdf](#studentt_cdfx-float64-dof-int64)
+* [studentt_cdf](#studentt_cdfx-float64-dof-float64)
 * [sure_cond](#sure_cond)
 * [sure_like](#sure_like)
 * [sure_nonnull](#sure_nonnull)
@@ -2360,7 +2360,7 @@ Results:
 
 ---
 
-### [studentt_cdf(x FLOAT64, dof INT64)](studentt_cdf.sqlx)
+### [studentt_cdf(x FLOAT64, dof FLOAT64)](studentt_cdf.sqlx)
 
 Returns the value of x in the cdf of the Student's T distribution with dof degrees of freedom.
 

--- a/udfs/community/studentt_cdf.sqlx
+++ b/udfs/community/studentt_cdf.sqlx
@@ -1,0 +1,28 @@
+config { hasOutput: true }
+
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+CREATE OR REPLACE FUNCTION ${self()}(x FLOAT64, dof INT64)
+RETURNS FLOAT64
+LANGUAGE js AS """
+  return jstat['jStat']['studentt']['cdf']( x, dof )
+"""
+OPTIONS (
+	    library=["${JS_BUCKET}/jstat-v1.9.4.min.js"]
+);
+

--- a/udfs/community/studentt_cdf.sqlx
+++ b/udfs/community/studentt_cdf.sqlx
@@ -17,7 +17,7 @@ config { hasOutput: true }
  */
 
 
-CREATE OR REPLACE FUNCTION ${self()}(x FLOAT64, dof INT64)
+CREATE OR REPLACE FUNCTION ${self()}(x FLOAT64, dof FLOAT64)
 RETURNS FLOAT64
 LANGUAGE js AS """
   return jstat['jStat']['studentt']['cdf']( x, dof )

--- a/udfs/community/test_cases.js
+++ b/udfs/community/test_cases.js
@@ -1205,6 +1205,15 @@ generate_udf_test("normal_cdf", [
 	expected_output: `CAST(0.3820885778110474 AS FLOAT64)`
     },
 ]);
+generate_udf_test("studentt_cdf", [
+    {
+        inputs: [
+		`CAST(1.0 AS FLOAT64)`,
+		`CAST(2 AS INT64)`
+	],
+	expected_output: `CAST(0.788675134594813 AS FLOAT64)`
+    },
+]);
 //
 // End of StatsLib work tests
 //
@@ -1503,7 +1512,7 @@ generate_udf_test("cw_map_create", [
             `CAST([1, 2, 3] AS ARRAY<INT64>)`,
             `CAST(["A", "B", "C"] AS ARRAY<STRING>)`
         ],
-        expected_output: `([STRUCT(CAST(1 AS INT64) AS key, "A" AS value), 
+        expected_output: `([STRUCT(CAST(1 AS INT64) AS key, "A" AS value),
                            STRUCT(CAST(2 AS INT64) AS key, "B" AS value),
                            STRUCT(CAST(3 AS INT64) AS key, "C" AS value)])`
     },
@@ -2862,7 +2871,7 @@ generate_udf_test("cw_strtok", [
             `"Test#1"`,
             `"#"`
         ],
-        expected_output: `([STRUCT(CAST(1 AS INT64) AS tokennumber, "Test" AS token), 
+        expected_output: `([STRUCT(CAST(1 AS INT64) AS tokennumber, "Test" AS token),
                            STRUCT(CAST(2 AS INT64) AS tokennumber, "1" AS token)])`
     },
 ]);
@@ -2982,7 +2991,7 @@ generate_udf_test("cw_regexp_split", [
             `"#"`,
             `"i"`
         ],
-        expected_output: `([STRUCT(CAST(1 AS INT64) AS tokennumber, "Test" AS token), 
+        expected_output: `([STRUCT(CAST(1 AS INT64) AS tokennumber, "Test" AS token),
                            STRUCT(CAST(2 AS INT64) AS tokennumber, "1" AS token)])`
     },
 ]);
@@ -3002,7 +3011,7 @@ generate_udf_test("cw_json_enumerate_array", [
         inputs: [
             `'[{"name":"Cameron"}, {"name":"John"}]'`
         ],
-        expected_output: `([STRUCT(CAST(1 AS INT64) AS ordinal, '{"name":"Cameron"}' AS jsonvalue), 
+        expected_output: `([STRUCT(CAST(1 AS INT64) AS ordinal, '{"name":"Cameron"}' AS jsonvalue),
                            STRUCT(CAST(2 AS INT64) AS ordinal, '{"name":"John"}' AS jsonvalue)])`
     },
 ]);
@@ -3056,7 +3065,7 @@ generate_udf_test("cw_map_parse", [
             `" "`,
             `"="`
         ],
-        expected_output: `([STRUCT("a" AS key, "1" AS value), 
+        expected_output: `([STRUCT("a" AS key, "1" AS value),
                            STRUCT("b" AS key, "42" AS value)])`
     },
 ]);
@@ -3096,7 +3105,7 @@ generate_udf_test("cw_ts_overlap_buckets", [
     {
         inputs: [
             `CAST(false AS BOOL)`,
-            `([STRUCT(TIMESTAMP("2008-12-25"), TIMESTAMP("2008-12-31")), 
+            `([STRUCT(TIMESTAMP("2008-12-25"), TIMESTAMP("2008-12-31")),
             STRUCT(TIMESTAMP("2008-12-26"), TIMESTAMP("2008-12-30"))])`
         ],
         expected_output: `([STRUCT(1 AS bucketNo, CAST("2008-12-25 00:00:00 UTC" AS TIMESTAMP) AS st, CAST("2008-12-31 00:00:00 UTC" AS TIMESTAMP) AS et)])`
@@ -3287,7 +3296,7 @@ generate_udf_test("bignumber_sum", [
     {
         inputs: [
             `ARRAY<STRING>[
-                "99999999999999999999999999999999999999999999999999999999999999999999", 
+                "99999999999999999999999999999999999999999999999999999999999999999999",
                 "893427328732842662772591830391462182598436547786876876876",
                 "123456789123456789123456789123456789123456789123456789123456789123456789"
             ]`
@@ -3297,7 +3306,7 @@ generate_udf_test("bignumber_sum", [
     {
         inputs: [
             `ARRAY<STRING>[
-                "99999999999999999999999999999999999999999999999999999999999999999999", 
+                "99999999999999999999999999999999999999999999999999999999999999999999",
                 "",
                 "123456789123456789123456789123456789123456789123456789123456789123456789"
             ]`
@@ -3307,7 +3316,7 @@ generate_udf_test("bignumber_sum", [
     {
         inputs: [
             `ARRAY<STRING>[
-                "99999999999999999999999999999999999999999999999999999999999999999999", 
+                "99999999999999999999999999999999999999999999999999999999999999999999",
                 "893427328732842662772591830391462182598436547786876876876",
                 NULL
             ]`
@@ -3320,7 +3329,7 @@ generate_udf_test("bignumber_avg", [
     {
         inputs: [
             `ARRAY<STRING>[
-                "99999999999999999999999999999999999999999999999999999999999999999999", 
+                "99999999999999999999999999999999999999999999999999999999999999999999",
                 "33333333333333333333333333333333333333333333333333333333333333333333",
                 "66666666666666666666666666666666666666666666666666666666666666666666"
             ]`
@@ -3330,7 +3339,7 @@ generate_udf_test("bignumber_avg", [
     {
         inputs: [
             `ARRAY<STRING>[
-                "99999999999999999999999999999999999999999999999999999999999999999999", 
+                "99999999999999999999999999999999999999999999999999999999999999999999",
                 "",
                 "123456789123456789123456789123456789123456789123456789123456789123456789"
             ]`
@@ -3340,7 +3349,7 @@ generate_udf_test("bignumber_avg", [
     {
         inputs: [
             `ARRAY<STRING>[
-                "99999999999999999999999999999999999999999999999999999999999999999999", 
+                "99999999999999999999999999999999999999999999999999999999999999999999",
                 "893427328732842662772591830391462182598436547786876876876",
                 NULL
             ]`

--- a/udfs/community/test_cases.js
+++ b/udfs/community/test_cases.js
@@ -1209,7 +1209,7 @@ generate_udf_test("studentt_cdf", [
     {
         inputs: [
 		`CAST(1.0 AS FLOAT64)`,
-		`CAST(2 AS INT64)`
+		`CAST(2.0 AS FLOAT64)`
 	],
 	expected_output: `CAST(0.788675134594813 AS FLOAT64)`
     },

--- a/udfs/community/test_cases.js
+++ b/udfs/community/test_cases.js
@@ -1512,7 +1512,7 @@ generate_udf_test("cw_map_create", [
             `CAST([1, 2, 3] AS ARRAY<INT64>)`,
             `CAST(["A", "B", "C"] AS ARRAY<STRING>)`
         ],
-        expected_output: `([STRUCT(CAST(1 AS INT64) AS key, "A" AS value),
+        expected_output: `([STRUCT(CAST(1 AS INT64) AS key, "A" AS value), 
                            STRUCT(CAST(2 AS INT64) AS key, "B" AS value),
                            STRUCT(CAST(3 AS INT64) AS key, "C" AS value)])`
     },
@@ -2871,7 +2871,7 @@ generate_udf_test("cw_strtok", [
             `"Test#1"`,
             `"#"`
         ],
-        expected_output: `([STRUCT(CAST(1 AS INT64) AS tokennumber, "Test" AS token),
+        expected_output: `([STRUCT(CAST(1 AS INT64) AS tokennumber, "Test" AS token), 
                            STRUCT(CAST(2 AS INT64) AS tokennumber, "1" AS token)])`
     },
 ]);
@@ -2991,7 +2991,7 @@ generate_udf_test("cw_regexp_split", [
             `"#"`,
             `"i"`
         ],
-        expected_output: `([STRUCT(CAST(1 AS INT64) AS tokennumber, "Test" AS token),
+        expected_output: `([STRUCT(CAST(1 AS INT64) AS tokennumber, "Test" AS token), 
                            STRUCT(CAST(2 AS INT64) AS tokennumber, "1" AS token)])`
     },
 ]);
@@ -3011,7 +3011,7 @@ generate_udf_test("cw_json_enumerate_array", [
         inputs: [
             `'[{"name":"Cameron"}, {"name":"John"}]'`
         ],
-        expected_output: `([STRUCT(CAST(1 AS INT64) AS ordinal, '{"name":"Cameron"}' AS jsonvalue),
+        expected_output: `([STRUCT(CAST(1 AS INT64) AS ordinal, '{"name":"Cameron"}' AS jsonvalue), 
                            STRUCT(CAST(2 AS INT64) AS ordinal, '{"name":"John"}' AS jsonvalue)])`
     },
 ]);
@@ -3065,7 +3065,7 @@ generate_udf_test("cw_map_parse", [
             `" "`,
             `"="`
         ],
-        expected_output: `([STRUCT("a" AS key, "1" AS value),
+        expected_output: `([STRUCT("a" AS key, "1" AS value), 
                            STRUCT("b" AS key, "42" AS value)])`
     },
 ]);
@@ -3105,7 +3105,7 @@ generate_udf_test("cw_ts_overlap_buckets", [
     {
         inputs: [
             `CAST(false AS BOOL)`,
-            `([STRUCT(TIMESTAMP("2008-12-25"), TIMESTAMP("2008-12-31")),
+            `([STRUCT(TIMESTAMP("2008-12-25"), TIMESTAMP("2008-12-31")), 
             STRUCT(TIMESTAMP("2008-12-26"), TIMESTAMP("2008-12-30"))])`
         ],
         expected_output: `([STRUCT(1 AS bucketNo, CAST("2008-12-25 00:00:00 UTC" AS TIMESTAMP) AS st, CAST("2008-12-31 00:00:00 UTC" AS TIMESTAMP) AS et)])`
@@ -3296,7 +3296,7 @@ generate_udf_test("bignumber_sum", [
     {
         inputs: [
             `ARRAY<STRING>[
-                "99999999999999999999999999999999999999999999999999999999999999999999",
+                "99999999999999999999999999999999999999999999999999999999999999999999", 
                 "893427328732842662772591830391462182598436547786876876876",
                 "123456789123456789123456789123456789123456789123456789123456789123456789"
             ]`
@@ -3306,7 +3306,7 @@ generate_udf_test("bignumber_sum", [
     {
         inputs: [
             `ARRAY<STRING>[
-                "99999999999999999999999999999999999999999999999999999999999999999999",
+                "99999999999999999999999999999999999999999999999999999999999999999999", 
                 "",
                 "123456789123456789123456789123456789123456789123456789123456789123456789"
             ]`
@@ -3316,7 +3316,7 @@ generate_udf_test("bignumber_sum", [
     {
         inputs: [
             `ARRAY<STRING>[
-                "99999999999999999999999999999999999999999999999999999999999999999999",
+                "99999999999999999999999999999999999999999999999999999999999999999999", 
                 "893427328732842662772591830391462182598436547786876876876",
                 NULL
             ]`
@@ -3329,7 +3329,7 @@ generate_udf_test("bignumber_avg", [
     {
         inputs: [
             `ARRAY<STRING>[
-                "99999999999999999999999999999999999999999999999999999999999999999999",
+                "99999999999999999999999999999999999999999999999999999999999999999999", 
                 "33333333333333333333333333333333333333333333333333333333333333333333",
                 "66666666666666666666666666666666666666666666666666666666666666666666"
             ]`
@@ -3339,7 +3339,7 @@ generate_udf_test("bignumber_avg", [
     {
         inputs: [
             `ARRAY<STRING>[
-                "99999999999999999999999999999999999999999999999999999999999999999999",
+                "99999999999999999999999999999999999999999999999999999999999999999999", 
                 "",
                 "123456789123456789123456789123456789123456789123456789123456789123456789"
             ]`
@@ -3349,7 +3349,7 @@ generate_udf_test("bignumber_avg", [
     {
         inputs: [
             `ARRAY<STRING>[
-                "99999999999999999999999999999999999999999999999999999999999999999999",
+                "99999999999999999999999999999999999999999999999999999999999999999999", 
                 "893427328732842662772591830391462182598436547786876876876",
                 NULL
             ]`


### PR DESCRIPTION
Adding `studentt_cdf` UDF. The UDF uses [jStat.studentt.cdf](https://jstat.github.io/distributions.html#jStat.studentt.cdf) function.

### [studentt_cdf(x FLOAT64, dof FLOAT64)](studentt_cdf.sqlx)

Returns the value of x in the cdf of the Student's T distribution with dof degrees of freedom.

Sample Query:

```SQL
SELECT `bqutils.fn.studentt_cdf`(1.0, 2.0) as studentt_cdf;
```

Results:

| Row | studentt_cdf      |
| --- | ----------------- |
| 1   | 0.788675134594813 |