### PR TITLE
[Sketch] Make merge more defensive for calling order

### DIFF
--- a/udfs/community/kll_sketch_int64.sqlx
+++ b/udfs/community/kll_sketch_int64.sqlx
@@ -142,14 +142,9 @@ export function deserialize(serialized) {
   };
 }
 
-// Assuming Merge can only be called after deserialize
 export function merge(state, other_state) {
   if (!state.sketch) {
     state.sketch = Module._kll_sketch_initialize(state.k);
-  }
-
-  if (other_state.sketch ) {
-    throw new Error("Did not expect sketch in other state");
   }
 
   if (state.serialized) {
@@ -158,11 +153,15 @@ export function merge(state, other_state) {
     state.serialized = null;
   }
 
+  if (other_state.sketch ) {
+    Module._merge_sketch(state.sketch, other_state.sketch);
+    Module._kll_sketch_destroy(other_state.sketch);
+    other_state.sketch = 0;
+  }
+
   if (other_state.serialized) {
     updateSketch(state.sketch, other_state.serialized);
     other_state.serialized = null;
-  } else {
-    throw new Error("Expected serialized sketch on other_state");
   }
 }
 

--- a/udfs/community/theta_sketch_bytes.sqlx
+++ b/udfs/community/theta_sketch_bytes.sqlx
@@ -157,17 +157,22 @@ export function deserialize(serialized) {
   };
 }
 
+// Possible states:
+// - first (or only) merge, union is absent on left hand side
+// - iterative merge, union is present on left hand side
+//   - union should be absent on the right hand side
+//   - should we defend against this?
+// - merge-after-update, sketch is present on left or right hand side
+// - merge-after-serialize, serialized is present on left or right hand side
 export function merge(state, other_state) {
   if (!state.union) {
     state.union = Module._theta_union_initialize(state.lg_k);
   }
 
-  if (state.sketch || other_state.sketch) {
-    throw new Error("update_sketch not expected during merge()");
-  }
-
-  if (other_state.union) {
-    throw new Error("other_state should not have union during merge()");
+  if (state.sketch) {
+    Module._theta_union_update_sketch(state.union, state.sketch);
+    Module._update_sketch_destroy(state.sketch);
+    state.sketch = 0;
   }
 
   if (state.serialized) {
@@ -176,11 +181,22 @@ export function merge(state, other_state) {
     state.serialized = null;
   }
 
+  if (other_state.union) {
+    throw new Error("other_state should not have union during merge()");
+  }
+  if (!other_state.sketch && !other_state.serialized) {
+    throw new Error("Expected sketch on other_state");
+  }
+
+  if (other_state.sketch) {
+    Module._theta_union_update_sketch(state.union, other_state.sketch);
+    Module._update_sketch_destroy(other_state.sketch);
+    other_state.sketch = 0;
+  }
+
   if (other_state.serialized) {
     updateUnion(state.union, other_state.serialized);
     other_state.serialized = null;
-  } else {
-    throw new Error("Expected serialized sketch on other_state");
   }
 }
 

--- a/udfs/community/theta_sketch_int64.sqlx
+++ b/udfs/community/theta_sketch_int64.sqlx
@@ -146,12 +146,10 @@ export function merge(state, other_state) {
     state.union = Module._theta_union_initialize(state.lg_k);
   }
 
-  if (state.sketch || other_state.sketch) {
-    throw new Error("update_sketch not expected during merge()");
-  }
-
-  if (other_state.union) {
-    throw new Error("other_state should not have union during merge()");
+  if (state.sketch) {
+    Module._theta_union_update_sketch(state.union, state.sketch);
+    Module._update_sketch_destroy(state.sketch);
+    state.sketch = 0;
   }
 
   if (state.serialized) {
@@ -160,11 +158,22 @@ export function merge(state, other_state) {
     state.serialized = null;
   }
 
+  if (other_state.union) {
+    throw new Error("other_state should not have union during merge()");
+  }
+  if (!other_state.sketch && !other_state.serialized) {
+    throw new Error("Expected sketch on other_state");
+  }
+
+  if (other_state.sketch) {
+    Module._theta_union_update_sketch(state.union, other_state.sketch);
+    Module._update_sketch_destroy(other_state.sketch);
+    other_state.sketch = 0;
+  }
+
   if (other_state.serialized) {
     updateUnion(state.union, other_state.serialized);
     other_state.serialized = null;
-  } else {
-    throw new Error("Expected serialized sketch on other_state");
   }
 }
 

--- a/udfs/community/tuple_sketch_int64.sqlx
+++ b/udfs/community/tuple_sketch_int64.sqlx
@@ -147,12 +147,10 @@ export function merge(state, other_state) {
     state.union = Module._tuple_union_initialize(state.lg_k);
   }
 
-  if (state.sketch || other_state.sketch) {
-    throw new Error("update_sketch not expected during merge()");
-  }
-
-  if (other_state.union) {
-    throw new Error("other_state should not have union during merge()");
+  if (state.sketch)
+    Module._tuple_union_update_sketch(state.union, state.sketch);
+    Module._update_sketch_destroy(state.sketch);
+    state.sketch = 0;
   }
 
   if (state.serialized) {
@@ -161,11 +159,23 @@ export function merge(state, other_state) {
     state.serialized = null;
   }
 
+  if (other_state.union) {
+    throw new Error("other_state should not have union during merge()");
+  }
+
+  if (!other_state.sketch && !other_state.serialized) {
+    throw new Error("Expected sketch on other_state");
+  }
+
+  if (other_state.sketch) {
+    Module._tuple_union_update_sketch(state.union, other_state.sketch);
+    Module._update_sketch_destroy(other_state.sketch);
+    other_state.sketch = 0;
+  }
+
   if (other_state.serialized) {
     updateUnion(state.union, other_state.serialized);
     other_state.serialized = null;
-  } else {
-    throw new Error("Expected serialized sketch on other_state");
   }
 }
 

--- a/udfs/community/tuple_sketch_int64.sqlx
+++ b/udfs/community/tuple_sketch_int64.sqlx
@@ -147,7 +147,7 @@ export function merge(state, other_state) {
     state.union = Module._tuple_union_initialize(state.lg_k);
   }
 
-  if (state.sketch)
+  if (state.sketch) {
     Module._tuple_union_update_sketch(state.union, state.sketch);
     Module._update_sketch_destroy(state.sketch);
     state.sketch = 0;

--- a/udfs/datasketches/theta-sketch/theta_sketch.cpp
+++ b/udfs/datasketches/theta-sketch/theta_sketch.cpp
@@ -133,7 +133,7 @@ EMSCRIPTEN_KEEPALIVE void theta_union_update_buffer(
 }
 
 EMSCRIPTEN_KEEPALIVE void theta_union_update_sketch(
-    theta_union * theta_union, compact_theta_sketch *sketch) {
+    theta_union *theta_union, update_theta_sketch *sketch) {
   theta_union->update(*sketch);
 }
 

--- a/udfs/datasketches/tuple-sketch/tuple_sketch.cpp
+++ b/udfs/datasketches/tuple-sketch/tuple_sketch.cpp
@@ -154,7 +154,7 @@ EMSCRIPTEN_KEEPALIVE void tuple_union_update_buffer(
 }
 
 EMSCRIPTEN_KEEPALIVE void tuple_union_update_sketch(
-    tuple_union * tuple_union, compact_tuple_sketch *sketch) {
+    tuple_union *tuple_union, update_tuple_sketch *sketch) {
   tuple_union->update(*sketch);
 }
 


### PR DESCRIPTION
The existing implementations assume that merge() only ever happens after deserialization. This assumption is invalid, and the implementation should be correct for merge() directly after aggregation.