### PR TITLE
fix: honor `offset` when `occurence` is 0

### DIFF
--- a/udfs/community/cw_regexp_replace_generic.sqlx
+++ b/udfs/community/cw_regexp_replace_generic.sqlx
@@ -22,7 +22,7 @@ LANGUAGE js AS """
   replacement = replacement.replace('\\\\', '$');
   let regExp = new RegExp(regexp, mode);
   if (occurrence == 0)
-      return haystack.replace(regExp, replacement);
+      return haystack.substr(offset).replace(regExp, replacement);
   const start = offset - 1;
   const index = occurrence - 1;
   let relevantString = haystack.substring(start);

--- a/udfs/community/cw_regexp_replace_generic.sqlx
+++ b/udfs/community/cw_regexp_replace_generic.sqlx
@@ -21,9 +21,9 @@ LANGUAGE js AS """
   if (haystack == null || regexp == null || replacement == null || offset == null || occurrence == null || mode == null) return null;
   replacement = replacement.replace('\\\\', '$');
   let regExp = new RegExp(regexp, mode);
-  if (occurrence == 0)
-      return haystack.substr(offset).replace(regExp, replacement);
   const start = offset - 1;
+  if (occurrence == 0)
+      return haystack.substr(start).replace(regExp, replacement);
   const index = occurrence - 1;
   let relevantString = haystack.substring(start);
   let a, count = 0;

--- a/udfs/community/cw_regexp_replace_generic.sqlx
+++ b/udfs/community/cw_regexp_replace_generic.sqlx
@@ -23,7 +23,7 @@ LANGUAGE js AS """
   let regExp = new RegExp(regexp, mode);
   const start = offset - 1;
   if (occurrence == 0)
-      return haystack.substr(start).replace(regExp, replacement);
+      return haystack.substr(0, start) + haystack.substr(start).replace(regExp, replacement);
   const index = occurrence - 1;
   let relevantString = haystack.substring(start);
   let a, count = 0;

--- a/udfs/community/test_cases.js
+++ b/udfs/community/test_cases.js
@@ -1449,6 +1449,24 @@ generate_udf_test("cw_regexp_replace_4", [
     expected_output: `"TestCad$123456"`,
   },
 ]);
+generate_udf_test("cw_regexp_replace_4", [
+  {
+    inputs: [`"TestStr123456Str"`, `"Str"`, `"Cad$"`, `CAST(1 AS INT64)`],
+    expected_output: `"TestCad$123456Cad$"`,
+  },
+]);
+generate_udf_test("cw_regexp_replace_4", [
+  {
+    inputs: [`"abaa"`, `"a"`, `"A"`, `CAST(1 AS INT64)`],
+    expected_output: `"AbAA"`,
+  },
+]);
+generate_udf_test("cw_regexp_replace_4", [
+  {
+    inputs: [`"abaa"`, `"a"`, `"A"`, `CAST(2 AS INT64)`],
+    expected_output: `"abAA"`,
+  },
+]);
 generate_udf_test("cw_regexp_replace_5", [
   {
     inputs: [


### PR DESCRIPTION
```sql
SELECT bqutil.fn.cw_regexp_replace_4('abaa', 'a', 'A', 1)
```

Current behavior:
```
AbAA
```

Expected behavior:
```
abAA
```
