### PR TITLE
Update job_execution.sql

### DIFF
--- a/dashboards/system_tables/sql/job_execution.sql
+++ b/dashboards/system_tables/sql/job_execution.sql
@@ -33,7 +33,7 @@ SELECT
   EXTRACT(DATE FROM creation_time) AS creation_date,
   creation_time,
   end_time,
-  TIMESTAMP_DIFF(end_time, start_time, SECOND) AS job_duration_seconds,
+  TIMESTAMP_DIFF(COALESCE(end_time, CURRENT_TIMESTAMP()), start_time, SECOND) AS job_duration_seconds,
   job_type,
   user_email,
   state,


### PR DESCRIPTION
Changed the calculation of job_duration_seconds in the job_execution.sql

If the job is running then end_time is null. Therefore an admin cannot easily visualize for how long the a job has been running until it is done.

With this change, if the job is not done then job_duration_seconds is calculates as the difference between start time and current time. Thus and admin can know easily identify the duration of a RUNNING / PENDING job and identify long running / troublesome jobs.