### PR TITLE
Fix embedding batch table path to be wrapped in backticks

### DIFF
--- a/stored_procedures/definitions/bqml_generate_embeddings.sqlx
+++ b/stored_procedures/definitions/bqml_generate_embeddings.sqlx
@@ -171,7 +171,7 @@ EXECUTE
       CREATE TEMP TABLE _SESSION.embedding_batch AS
       (SELECT *
           FROM (%s) AS S
-          WHERE NOT EXISTS (SELECT * FROM %s AS T WHERE %s) LIMIT %d)
+          WHERE NOT EXISTS (SELECT * FROM `%s` AS T WHERE %s) LIMIT %d)
     ''',
       ml_query,
       target_table,


### PR DESCRIPTION
I was making use of the very awesome `bqml_generate_embeddings` stored procedure and noticed that for the target table, the full path wasn't wrapped in backticks in one spot which causes the call to fail if the project name or table name have odd characters (like a `-` for example)