### PR TITLE
Add functions for emulating Snowflake/Postgresql's mode()

### DIFF
--- a/udfs/community/cw_mode_boolean.sqlx
+++ b/udfs/community/cw_mode_boolean.sqlx
@@ -1,0 +1,54 @@
+config { hasOutput: true }
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Returns the most frequently occurring argument */
+CREATE OR REPLACE AGGREGATE FUNCTION ${self()}(b BOOLEAN)
+RETURNS BOOLEAN
+LANGUAGE js AS """
+  export function initialState() {
+    return {frequencyMap: new Map()};
+  }
+  export function aggregate(state, value) {
+    var frequencyMap  = state.frequencyMap;
+    if (frequencyMap.has(value)) {
+      frequencyMap.set(value, frequencyMap.get(value) + 1);
+    } else {
+      frequencyMap.set(value, 1);
+    }
+  }
+  export function merge(state, partial_state) {
+    var frequencyMap  = state.frequencyMap;
+    for (let [key, count] of partial_state.frequencyMap) {
+      if (frequencyMap.has(key)) {
+        frequencyMap.set(key, frequencyMap.get(key) + count);
+      } else {
+        frequencyMap.set(key, count);
+      }
+    }
+  }
+  export function finalize(state) {
+    var maxCount = 0;
+    var maxKey = null;
+    for (let [key, count] of state.frequencyMap) {
+      if (count > maxCount) {
+        maxKey = key;
+        maxCount = count;
+      }
+    }
+    return maxKey;
+  }
+""";

--- a/udfs/community/cw_mode_boolean.sqlx
+++ b/udfs/community/cw_mode_boolean.sqlx
@@ -15,10 +15,13 @@ config { hasOutput: true }
  * limitations under the License.
  */
 
-/** Returns the most frequently occurring argument */
 CREATE OR REPLACE AGGREGATE FUNCTION ${self()}(b BOOLEAN)
 RETURNS BOOLEAN
-LANGUAGE js AS """
+LANGUAGE js 
+OPTIONS (
+  description="Returns the most frequently occurring argument"
+)
+AS """
   export function initialState() {
     return {frequencyMap: new Map()};
   }

--- a/udfs/community/cw_mode_bytes.sqlx
+++ b/udfs/community/cw_mode_bytes.sqlx
@@ -1,0 +1,54 @@
+config { hasOutput: true }
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Returns the most frequently occurring argument */
+CREATE OR REPLACE AGGREGATE FUNCTION ${self()}(b BYTES)
+RETURNS BYTES
+LANGUAGE js AS """
+  export function initialState() {
+    return {frequencyMap: new Map()};
+  }
+  export function aggregate(state, value) {
+    var frequencyMap  = state.frequencyMap;
+    if (frequencyMap.has(value)) {
+      frequencyMap.set(value, frequencyMap.get(value) + 1);
+    } else {
+      frequencyMap.set(value, 1);
+    }
+  }
+  export function merge(state, partial_state) {
+    var frequencyMap  = state.frequencyMap;
+    for (let [key, count] of partial_state.frequencyMap) {
+      if (frequencyMap.has(key)) {
+        frequencyMap.set(key, frequencyMap.get(key) + count);
+      } else {
+        frequencyMap.set(key, count);
+      }
+    }
+  }
+  export function finalize(state) {
+    var maxCount = 0;
+    var maxKey = null;
+    for (let [key, count] of state.frequencyMap) {
+      if (count > maxCount) {
+        maxKey = key;
+        maxCount = count;
+      }
+    }
+    return maxKey;
+  }
+""";

--- a/udfs/community/cw_mode_bytes.sqlx
+++ b/udfs/community/cw_mode_bytes.sqlx
@@ -15,10 +15,13 @@ config { hasOutput: true }
  * limitations under the License.
  */
 
-/** Returns the most frequently occurring argument */
 CREATE OR REPLACE AGGREGATE FUNCTION ${self()}(b BYTES)
 RETURNS BYTES
-LANGUAGE js AS """
+LANGUAGE js 
+OPTIONS (
+  description="Returns the most frequently occurring argument"
+)
+AS """
   export function initialState() {
     return {frequencyMap: new Map()};
   }

--- a/udfs/community/cw_mode_date.sqlx
+++ b/udfs/community/cw_mode_date.sqlx
@@ -1,0 +1,54 @@
+config { hasOutput: true }
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Returns the most frequently occurring argument */
+CREATE OR REPLACE AGGREGATE FUNCTION ${self()}(d DATE)
+RETURNS DATE
+LANGUAGE js AS """
+  export function initialState() {
+    return {frequencyMap: new Map()};
+  }
+  export function aggregate(state, value) {
+    var frequencyMap  = state.frequencyMap;
+    if (frequencyMap.has(value)) {
+      frequencyMap.set(value, frequencyMap.get(value) + 1);
+    } else {
+      frequencyMap.set(value, 1);
+    }
+  }
+  export function merge(state, partial_state) {
+    var frequencyMap  = state.frequencyMap;
+    for (let [key, count] of partial_state.frequencyMap) {
+      if (frequencyMap.has(key)) {
+        frequencyMap.set(key, frequencyMap.get(key) + count);
+      } else {
+        frequencyMap.set(key, count);
+      }
+    }
+  }
+  export function finalize(state) {
+    var maxCount = 0;
+    var maxKey = null;
+    for (let [key, count] of state.frequencyMap) {
+      if (count > maxCount) {
+        maxKey = key;
+        maxCount = count;
+      }
+    }
+    return maxKey;
+  }
+""";

--- a/udfs/community/cw_mode_date.sqlx
+++ b/udfs/community/cw_mode_date.sqlx
@@ -15,10 +15,13 @@ config { hasOutput: true }
  * limitations under the License.
  */
 
-/** Returns the most frequently occurring argument */
 CREATE OR REPLACE AGGREGATE FUNCTION ${self()}(d DATE)
 RETURNS DATE
-LANGUAGE js AS """
+LANGUAGE js 
+OPTIONS (
+  description="Returns the most frequently occurring argument"
+)
+AS """
   export function initialState() {
     return {frequencyMap: new Map()};
   }

--- a/udfs/community/cw_mode_float64.sqlx
+++ b/udfs/community/cw_mode_float64.sqlx
@@ -15,10 +15,13 @@ config { hasOutput: true }
  * limitations under the License.
  */
 
-/** Returns the most frequently occurring argument */
 CREATE OR REPLACE AGGREGATE FUNCTION ${self()}(n FLOAT64)
 RETURNS FLOAT64
-LANGUAGE js AS """
+LANGUAGE js 
+OPTIONS (
+  description="Returns the most frequently occurring argument"
+)
+AS """
   export function initialState() {
     return {frequencyMap: new Map()};
   }

--- a/udfs/community/cw_mode_float64.sqlx
+++ b/udfs/community/cw_mode_float64.sqlx
@@ -1,0 +1,54 @@
+config { hasOutput: true }
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Returns the most frequently occurring argument */
+CREATE OR REPLACE AGGREGATE FUNCTION ${self()}(n FLOAT64)
+RETURNS FLOAT64
+LANGUAGE js AS """
+  export function initialState() {
+    return {frequencyMap: new Map()};
+  }
+  export function aggregate(state, value) {
+    var frequencyMap  = state.frequencyMap;
+    if (frequencyMap.has(value)) {
+      frequencyMap.set(value, frequencyMap.get(value) + 1);
+    } else {
+      frequencyMap.set(value, 1);
+    }
+  }
+  export function merge(state, partial_state) {
+    var frequencyMap  = state.frequencyMap;
+    for (let [key, count] of partial_state.frequencyMap) {
+      if (frequencyMap.has(key)) {
+        frequencyMap.set(key, frequencyMap.get(key) + count);
+      } else {
+        frequencyMap.set(key, count);
+      }
+    }
+  }
+  export function finalize(state) {
+    var maxCount = 0;
+    var maxKey = null;
+    for (let [key, count] of state.frequencyMap) {
+      if (count > maxCount) {
+        maxKey = key;
+        maxCount = count;
+      }
+    }
+    return maxKey;
+  }
+""";

--- a/udfs/community/cw_mode_int64.sqlx
+++ b/udfs/community/cw_mode_int64.sqlx
@@ -1,0 +1,54 @@
+config { hasOutput: true }
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Returns the most frequently occurring argument */
+CREATE OR REPLACE AGGREGATE FUNCTION ${self()}(n INT64)
+RETURNS INT64
+LANGUAGE js AS """
+  export function initialState() {
+    return {frequencyMap: new Map()};
+  }
+  export function aggregate(state, value) {
+    var frequencyMap  = state.frequencyMap;
+    if (frequencyMap.has(value)) {
+      frequencyMap.set(value, frequencyMap.get(value) + 1);
+    } else {
+      frequencyMap.set(value, 1);
+    }
+  }
+  export function merge(state, partial_state) {
+    var frequencyMap  = state.frequencyMap;
+    for (let [key, count] of partial_state.frequencyMap) {
+      if (frequencyMap.has(key)) {
+        frequencyMap.set(key, frequencyMap.get(key) + count);
+      } else {
+        frequencyMap.set(key, count);
+      }
+    }
+  }
+  export function finalize(state) {
+    var maxCount = 0;
+    var maxKey = null;
+    for (let [key, count] of state.frequencyMap) {
+      if (count > maxCount) {
+        maxKey = key;
+        maxCount = count;
+      }
+    }
+    return maxKey;
+  }
+""";

--- a/udfs/community/cw_mode_int64.sqlx
+++ b/udfs/community/cw_mode_int64.sqlx
@@ -15,10 +15,13 @@ config { hasOutput: true }
  * limitations under the License.
  */
 
-/** Returns the most frequently occurring argument */
 CREATE OR REPLACE AGGREGATE FUNCTION ${self()}(n INT64)
 RETURNS INT64
-LANGUAGE js AS """
+LANGUAGE js 
+OPTIONS (
+  description="Returns the most frequently occurring argument"
+)
+AS """
   export function initialState() {
     return {frequencyMap: new Map()};
   }

--- a/udfs/community/cw_mode_json.sqlx
+++ b/udfs/community/cw_mode_json.sqlx
@@ -1,0 +1,54 @@
+config { hasOutput: true }
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Returns the most frequently occurring argument */
+CREATE OR REPLACE AGGREGATE FUNCTION ${self()}(j JSON)
+RETURNS JSON
+LANGUAGE js AS """
+  export function initialState() {
+    return {frequencyMap: new Map()};
+  }
+  export function aggregate(state, value) {
+    var frequencyMap  = state.frequencyMap;
+    if (frequencyMap.has(value)) {
+      frequencyMap.set(value, frequencyMap.get(value) + 1);
+    } else {
+      frequencyMap.set(value, 1);
+    }
+  }
+  export function merge(state, partial_state) {
+    var frequencyMap  = state.frequencyMap;
+    for (let [key, count] of partial_state.frequencyMap) {
+      if (frequencyMap.has(key)) {
+        frequencyMap.set(key, frequencyMap.get(key) + count);
+      } else {
+        frequencyMap.set(key, count);
+      }
+    }
+  }
+  export function finalize(state) {
+    var maxCount = 0;
+    var maxKey = null;
+    for (let [key, count] of state.frequencyMap) {
+      if (count > maxCount) {
+        maxKey = key;
+        maxCount = count;
+      }
+    }
+    return maxKey;
+  }
+""";

--- a/udfs/community/cw_mode_json.sqlx
+++ b/udfs/community/cw_mode_json.sqlx
@@ -15,10 +15,13 @@ config { hasOutput: true }
  * limitations under the License.
  */
 
-/** Returns the most frequently occurring argument */
 CREATE OR REPLACE AGGREGATE FUNCTION ${self()}(j JSON)
 RETURNS JSON
-LANGUAGE js AS """
+LANGUAGE js 
+OPTIONS (
+  description="Returns the most frequently occurring argument"
+)
+AS """
   export function initialState() {
     return {frequencyMap: new Map()};
   }

--- a/udfs/community/cw_mode_numeric.sqlx
+++ b/udfs/community/cw_mode_numeric.sqlx
@@ -1,0 +1,54 @@
+config { hasOutput: true }
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Returns the most frequently occurring argument */
+CREATE OR REPLACE AGGREGATE FUNCTION ${self()}(n NUMERIC)
+RETURNS NUMERIC
+LANGUAGE js AS """
+  export function initialState() {
+    return {frequencyMap: new Map()};
+  }
+  export function aggregate(state, value) {
+    var frequencyMap  = state.frequencyMap;
+    if (frequencyMap.has(value)) {
+      frequencyMap.set(value, frequencyMap.get(value) + 1);
+    } else {
+      frequencyMap.set(value, 1);
+    }
+  }
+  export function merge(state, partial_state) {
+    var frequencyMap  = state.frequencyMap;
+    for (let [key, count] of partial_state.frequencyMap) {
+      if (frequencyMap.has(key)) {
+        frequencyMap.set(key, frequencyMap.get(key) + count);
+      } else {
+        frequencyMap.set(key, count);
+      }
+    }
+  }
+  export function finalize(state) {
+    var maxCount = 0;
+    var maxKey = null;
+    for (let [key, count] of state.frequencyMap) {
+      if (count > maxCount) {
+        maxKey = key;
+        maxCount = count;
+      }
+    }
+    return maxKey;
+  }
+""";

--- a/udfs/community/cw_mode_numeric.sqlx
+++ b/udfs/community/cw_mode_numeric.sqlx
@@ -15,10 +15,13 @@ config { hasOutput: true }
  * limitations under the License.
  */
 
-/** Returns the most frequently occurring argument */
 CREATE OR REPLACE AGGREGATE FUNCTION ${self()}(n NUMERIC)
 RETURNS NUMERIC
-LANGUAGE js AS """
+LANGUAGE js 
+OPTIONS (
+  description="Returns the most frequently occurring argument"
+)
+AS """
   export function initialState() {
     return {frequencyMap: new Map()};
   }

--- a/udfs/community/cw_mode_string.sqlx
+++ b/udfs/community/cw_mode_string.sqlx
@@ -1,0 +1,54 @@
+config { hasOutput: true }
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Returns the most frequently occurring argument */
+CREATE OR REPLACE AGGREGATE FUNCTION ${self()}(s STRING)
+RETURNS STRING
+LANGUAGE js AS """
+  export function initialState() {
+    return {frequencyMap: new Map()};
+  }
+  export function aggregate(state, value) {
+    var frequencyMap  = state.frequencyMap;
+    if (frequencyMap.has(value)) {
+      frequencyMap.set(value, frequencyMap.get(value) + 1);
+    } else {
+      frequencyMap.set(value, 1);
+    }
+  }
+  export function merge(state, partial_state) {
+    var frequencyMap  = state.frequencyMap;
+    for (let [key, count] of partial_state.frequencyMap) {
+      if (frequencyMap.has(key)) {
+        frequencyMap.set(key, frequencyMap.get(key) + count);
+      } else {
+        frequencyMap.set(key, count);
+      }
+    }
+  }
+  export function finalize(state) {
+    var maxCount = 0;
+    var maxKey = null;
+    for (let [key, count] of state.frequencyMap) {
+      if (count > maxCount) {
+        maxKey = key;
+        maxCount = count;
+      }
+    }
+    return maxKey;
+  }
+""";

--- a/udfs/community/cw_mode_string.sqlx
+++ b/udfs/community/cw_mode_string.sqlx
@@ -15,10 +15,13 @@ config { hasOutput: true }
  * limitations under the License.
  */
 
-/** Returns the most frequently occurring argument */
 CREATE OR REPLACE AGGREGATE FUNCTION ${self()}(s STRING)
 RETURNS STRING
-LANGUAGE js AS """
+LANGUAGE js 
+OPTIONS (
+  description="Returns the most frequently occurring argument"
+)
+AS """
   export function initialState() {
     return {frequencyMap: new Map()};
   }

--- a/udfs/community/cw_mode_timestamp.sqlx
+++ b/udfs/community/cw_mode_timestamp.sqlx
@@ -15,10 +15,13 @@ config { hasOutput: true }
  * limitations under the License.
  */
 
-/** Returns the most frequently occurring argument */
 CREATE OR REPLACE AGGREGATE FUNCTION ${self()}(t TIMESTAMP)
 RETURNS TIMESTAMP
-LANGUAGE js AS """
+LANGUAGE js 
+OPTIONS (
+  description="Returns the most frequently occurring argument"
+)
+AS """
   export function initialState() {
     return {frequencyMap: new Map()};
   }

--- a/udfs/community/cw_mode_timestamp.sqlx
+++ b/udfs/community/cw_mode_timestamp.sqlx
@@ -1,0 +1,57 @@
+config { hasOutput: true }
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Returns the most frequently occurring argument */
+CREATE OR REPLACE AGGREGATE FUNCTION ${self()}(t TIMESTAMP)
+RETURNS TIMESTAMP
+LANGUAGE js AS """
+  export function initialState() {
+    return {frequencyMap: new Map()};
+  }
+  export function aggregate(state, value) {
+    // Date objects cannot be used as map keys, so convert to string here
+    // and convert back in `finalize()`.
+    const v = value.toISOString();
+    var frequencyMap  = state.frequencyMap;
+    if (frequencyMap.has(v)) {
+      frequencyMap.set(v, frequencyMap.get(v) + 1);
+    } else {
+      frequencyMap.set(v, 1);
+    }
+  }
+  export function merge(state, partial_state) {
+    var frequencyMap  = state.frequencyMap;
+    for (let [key, count] of partial_state.frequencyMap) {
+      if (frequencyMap.has(key)) {
+        frequencyMap.set(key, frequencyMap.get(key) + count);
+      } else {
+        frequencyMap.set(key, count);
+      }
+    }
+  }
+  export function finalize(state) {
+    var maxCount = 0;
+    var maxKey = null;
+    for (let [key, count] of state.frequencyMap) {
+      if (count > maxCount) {
+        maxKey = key;
+        maxCount = count;
+      }
+    }
+    return new Date(maxKey);
+  }
+""";

--- a/udfs/community/test_cases.js
+++ b/udfs/community/test_cases.js
@@ -3557,3 +3557,137 @@ generate_udf_test("xml_to_json", [
     expected_output: `JSON '{}'`,
   },
 ]);
+generate_udaf_test("cw_mode_int64",
+  {
+    input_columns: [`v`],
+    input_rows: `SELECT
+    10 AS v
+  UNION ALL
+  SELECT
+    10
+  UNION ALL
+  SELECT
+    10
+  UNION ALL
+  SELECT
+    30
+  UNION ALL
+  SELECT
+    20
+  UNION ALL
+  SELECT
+    21
+  UNION ALL
+  SELECT
+    20
+  UNION ALL
+  SELECT
+    20
+  UNION ALL
+  SELECT
+    25
+  UNION ALL
+  SELECT
+    10`,
+    expected_output: `10`
+  },
+);
+generate_udaf_test("cw_mode_boolean",
+  {
+    input_columns: [`v`],
+    input_rows: `SELECT
+    true AS v
+  UNION ALL
+  SELECT
+    false
+  UNION ALL
+  SELECT
+    true`,
+    expected_output: `true`
+  },
+);
+generate_udaf_test("cw_mode_date",
+  {
+    input_columns: [`v`],
+    input_rows: `SELECT
+    DATE "2024-10-09" AS v
+  UNION ALL
+  SELECT
+    DATE "2024-10-08"
+  UNION ALL
+  SELECT
+    DATE "2024-10-09"`,
+    expected_output: `DATE "2024-10-09"`
+  }
+);
+generate_udaf_test("cw_mode_float64",
+  {
+    input_columns: [`v`],
+    input_rows: `SELECT
+    1.0 AS v
+  UNION ALL
+  SELECT
+    2.0
+  UNION ALL
+  SELECT
+    1.0`,
+    expected_output: `1.0`
+  }
+);
+generate_udaf_test("cw_mode_json",
+  {
+    input_columns: [`v`],
+    input_rows: `SELECT
+    JSON '{"a": 1}' AS v
+  UNION ALL
+  SELECT
+    JSON '{"a": 3}'
+  UNION ALL
+  SELECT
+    JSON '{"a": 1}'`,
+    expected_output: `JSON '{"a": 1}'`
+  }
+);
+generate_udaf_test("cw_mode_numeric",
+  {
+    input_columns: [`v`],
+    input_rows: `SELECT
+    CAST(1 as NUMERIC) AS v
+  UNION ALL
+  SELECT
+    CAST(2 as NUMERIC)
+  UNION ALL
+  SELECT
+    CAST(1 as NUMERIC)`,
+    expected_output: `CAST(1 as NUMERIC)`
+  }
+);
+generate_udaf_test("cw_mode_string",
+  {
+    input_columns: [`v`],
+    input_rows: `SELECT
+    "a" AS v
+  UNION ALL
+  SELECT
+    "b"
+  UNION ALL
+  SELECT
+    "a"`,
+    expected_output: `"a"`
+  }
+);
+generate_udaf_test("cw_mode_timestamp",
+  {
+    input_columns: [`v`],
+    input_rows: `SELECT
+    TIMESTAMP "2024-10-9T12:34:56.999" AS v
+  UNION ALL
+  SELECT
+    TIMESTAMP "2024-10-9T12:34:56.789"
+  UNION ALL
+  SELECT
+    TIMESTAMP "2024-10-9T12:34:56.789"`,
+    expected_output: `TIMESTAMP "2024-10-9T12:34:56.789"`
+  }
+);
+


### PR DESCRIPTION
For b/357127978

Unfortunately I can't declare these as
```sql
CREATE OR REPLACE AGGREGATE FUNCTION ${self()}(b ANY TYPE)
RETURNS ANY TYPE
....
```

I've also noticed that it is possible to overload on types for `CREATE TEMPORARY FUNCTION` but not `CREATE FUNCTION`, thus these all have their argument types in the name.

If I've missed a way to avoid duplicating the code, please let me know.