### PR TITLE
[Snowflake] Add a new UDF cw_regexp_extract_all_start_pos.

### DIFF
--- a/udfs/community/README.md
+++ b/udfs/community/README.md
@@ -75,6 +75,7 @@ SELECT bqutil.fn.int(1.684)
 * [cw_regex_mode](#cw_regex_modemode-string)
 * [cw_regexp_extract](#cw_regexp_extractstr-string-regexp-string)
 * [cw_regexp_extract_all](#cw_regexp_extract_allstr-string-regexp-string)
+* [cw_regexp_extract_all_start_pos](#cw_regexp_extract_all_start_posstr-string-regexp-string-position-int64)
 * [cw_regexp_extract_all_n](#cw_regexp_extract_all_nstr-string-regexp-string-groupn-int64)
 * [cw_regexp_extract_n](#cw_regexp_extract_nstr-string-regexp-string-groupn-int64)
 * [cw_regexp_instr_2](#cw_regexp_instr_2haystack-string-needle-string)
@@ -804,6 +805,16 @@ Finds all occurrences of the regular expression regexp in str and returns the ca
 SELECT bqutil.fn.cw_regexp_extract_all_n('TestStr123456Str789', 'Str.*', 0);
 
 Str123456Str789
+```
+
+### [cw_regexp_extract_all_start_pos(str STRING, regexp STRING, position INT64)](cw_regexp_extract_all_start_pos.sqlx)
+Finds all occurrences of the regular expression regexp in str starting from position. Returns null if either str or regexp is null.
+```sql
+SELECT bqutil.fn.cw_regexp_extract_all_start_pos('TestStr123456Str789', 'Str.*', 2);
+SELECT bqutil.fn.cw_regexp_extract_all_start_pos('TestStr123456Str789', 'Str.*', 12);
+
+Str123456Str789
+Str789
 ```
 
 ### [cw_regexp_extract_n(str STRING, regexp STRING, groupn INT64)](cw_regexp_extract_n.sqlx)

--- a/udfs/community/cw_regexp_extract_all_start_pos.sqlx
+++ b/udfs/community/cw_regexp_extract_all_start_pos.sqlx
@@ -1,0 +1,39 @@
+config { hasOutput: true }
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Returns all occurrences of the regular expression `regexp` in `str` starting from the `position`, returns null if either str or regexp is null. */
+CREATE OR REPLACE FUNCTION ${self()}(str STRING, regexp STRING, position INT64) RETURNS ARRAY<STRING>
+LANGUAGE js
+OPTIONS (
+    description="Returns all occurrences of the regular expression `regexp` in `str` starting from the `position`, returns null if either str or regexp is null."
+)
+AS """
+  if (str == null || regexp == null || position == null) {
+    return null;
+  }
+  if (position <= 0) {
+    throw new Error("Position must be positive");
+  }
+  var r = new RegExp(regexp, 'g');
+  var o = [];
+  // -1 to account for `position` having 1-based indexing.
+  var str_from_position = str.substring(position - 1);
+  while ((a = r.exec(str_from_position)) !== null) {
+    o.push(a[0]);
+  }
+  return o;
+""";

--- a/udfs/community/test_cases.js
+++ b/udfs/community/test_cases.js
@@ -3558,4 +3558,158 @@ generate_udaf_test("cw_mode_timestamp",
     expected_output: `TIMESTAMP "2024-10-9T12:34:56.789"`
   }
 );
+generate_udf_test("cw_regexp_extract_all_start_pos", [
+  {
+    inputs: [`"abcdefg"`, `"c"`, `CAST(1 as INT64)`],
+    expected_output: `[ "c" ]`
+  },
+  {
+    inputs: [`"abcdefg"`, `"c"`, `CAST(2 as INT64)`],
+    expected_output: `[ "c" ]`
+  },
+  {
+    inputs: [`"abcdefg"`, `"c"`, `CAST(3 as INT64)`],
+    expected_output: `[ "c" ]`
+  },
+  {
+    inputs: [`"abcdefg"`, `"c"`, `CAST(4 as INT64)`],
+    expected_output: '[ ]'
+  },
+  {
+    inputs: [`"abababab"`, `"ab"`, `CAST(1 as INT64)`],
+    expected_output: `[ "ab", "ab", "ab", "ab" ]`
+  },
+  {
+    inputs: [`"abababab"`, `"ab"`, `CAST(2 as INT64)`],
+    expected_output: `[ "ab", "ab", "ab" ]`
+  },
+  {
+    inputs: [`"abababab"`, `"ab"`, `CAST(3 as INT64)`],
+    expected_output: `[ "ab", "ab", "ab" ]`
+  },
+  {
+    inputs: [`"abababab"`, `"ab"`, `CAST(4 as INT64)`],
+    expected_output: `[ "ab", "ab" ]`
+  },
+  {
+    inputs: [`"abababab"`, `"ab"`, `CAST(50 as INT64)`],
+    expected_output: `[ ]`
+  },
+  {
+    inputs: [`"abcdefg"`, `"g"`, `CAST(7 as INT64)`],
+    expected_output: `[ "g" ]`
+  },
+  {
+    inputs: [`"abcdefg"`, `"g"`, `CAST(6 as INT64)`],
+    expected_output: `[ "g" ]`
+  },
+  {
+    inputs: [`"abcdefg"`, `"g"`, `CAST(8 as INT64)`],
+    expected_output: `[ ]`
+  },
+  {
+    inputs: [`"abcdefg"`, `"z"`, `CAST(8 as INT64)`],
+    expected_output: `[ ]`
+  },
+  {
+    inputs: [`"aaaaaa"`, `"aa"`, `CAST(1 as INT64)`],
+    expected_output: `[ "aa", "aa", "aa" ]`
+  },
+  {
+    inputs: [`"aaaaaa"`, `"aa"`, `CAST(2 as INT64)`],
+    expected_output: `[ "aa", "aa" ]`
+  },
+  {
+    inputs: [`"aaaaaa"`, `"aa"`, `CAST(3 as INT64)`],
+    expected_output: `[ "aa", "aa" ]`
+  },
+  {
+    inputs: [`"aaaaaa"`, `"aa"`, `CAST(40 as INT64)`],
+    expected_output: `[ ]`
+  },
+  {
+    inputs: [`"abbcccdddde"`, `"c+"`, `CAST(1 as INT64)`],
+    expected_output: `[ "ccc" ]`
+  },
+  {
+    inputs: [`"abbcccdddde"`, `"c+"`, `CAST(4 as INT64)`],
+    expected_output: `[ "ccc" ]`
+  },
+  {
+    inputs: [`"abbcccdddde"`, `"d+"`, `CAST(1 as INT64)`],
+    expected_output: `[ "dddd" ]`
+  },
+  {
+    inputs: [`"abbcccdddde"`, `"d+"`, `CAST(7 as INT64)`],
+    expected_output: `[ "dddd" ]`
+  },
+  {
+    inputs: [`"abbcccdddde"`, `"d+"`, `CAST(80 as INT64)`],
+    expected_output: `[ ]`
+  },
+  {
+    inputs: [`"abc123def456"`, `"[0-9]+"`, `CAST(1 as INT64)`],
+    expected_output: `[ "123", "456" ]`
+  },
+  {
+    inputs: [`"abc123def456"`, `"[0-9]+"`, `CAST(4 as INT64)`],
+    expected_output: `[ "123", "456" ]`
+  },
+  {
+    inputs: [`"abc123def456"`, `"[0-9]+"`, `CAST(7 as INT64)`],
+    expected_output: `[ "456" ]`
+  },
+  {
+    inputs: [`NULL`, `"a"`, `CAST(1 as INT64)`],
+    expected_output: `CAST(NULL AS ARRAY<STRING>)`
+  },
+  {
+    inputs: [`NULL`, `"[0-9]+"`, `CAST(5 as INT64)`],
+    expected_output: `CAST(NULL AS ARRAY<STRING>)`
+  },
+  {
+    inputs: [`NULL`, `"abc"`, `CAST(10 as INT64)`],
+    expected_output: `CAST(NULL AS ARRAY<STRING>)`
+  },
+  {
+    inputs: [`"abc"`, `NULL`, `CAST(1 as INT64)`],
+    expected_output: `CAST(NULL AS ARRAY<STRING>)`
+  },
+  {
+    inputs: [`"12345"`, `NULL`, `CAST(3 as INT64)`],
+    expected_output: `CAST(NULL AS ARRAY<STRING>)`
+  },
+  {
+    inputs: [`"xyz"`, `NULL`, `CAST(7 as INT64)`],
+    expected_output: `CAST(NULL AS ARRAY<STRING>)`
+  },
+  {
+    inputs: [`"abc"`, `"a"`, `NULL`],
+    expected_output: `CAST(NULL AS ARRAY<STRING>)`
+  },
+  {
+    inputs: [`"123"`, `""`, `NULL`],
+    expected_output: `CAST(NULL AS ARRAY<STRING>)`
+  },
+  {
+    inputs: [`"test"`, `"t"`, `NULL`],
+    expected_output: `CAST(NULL AS ARRAY<STRING>)`
+  },
+  {
+    inputs: [`NULL`, `NULL`, `CAST(1 as INT64)`],
+    expected_output: `CAST(NULL AS ARRAY<STRING>)`
+  },
+  {
+    inputs: [`NULL`, `"a"`, `NULL`],
+    expected_output: `CAST(NULL AS ARRAY<STRING>)`
+  },
+  {
+    inputs: [`"abc"`, `NULL`, `NULL`],
+    expected_output: `CAST(NULL AS ARRAY<STRING>)`
+  },
+  {
+    inputs: [`NULL`, `NULL`, `NULL`],
+    expected_output: `CAST(NULL AS ARRAY<STRING>)`
+  },
+]);
 


### PR DESCRIPTION
Adds support for Snowflake and similar database systems that have `regexp_extract_all` / `regexp_substr_all` functions with a three-parameter signature where the third parameter in these functions specifies a 1-based start position for matching. This change addresses bug b/390757236.