### PR TITLE
escape target table parameter (#475)

### DIFF
--- a/stored_procedures/definitions/bqml_generate_text.sqlx
+++ b/stored_procedures/definitions/bqml_generate_text.sqlx
@@ -171,7 +171,7 @@ EXECUTE
       CREATE TEMP TABLE _SESSION.text_batch AS
       (SELECT *
           FROM (%s) AS S
-          WHERE NOT EXISTS (SELECT * FROM %s AS T WHERE %s) LIMIT %d)
+          WHERE NOT EXISTS (SELECT * FROM `%s` AS T WHERE %s) LIMIT %d)
     ''',
       ml_query,
       target_table,


### PR DESCRIPTION
Fix for issue #475 that escapes `target_table` parameter 