### PR TITLE
chore: fix unit test docker file

### DIFF
--- a/udfs/tests/Dockerfile.ci
+++ b/udfs/tests/Dockerfile.ci
@@ -2,7 +2,7 @@ FROM gcr.io/google.com/cloudsdktool/cloud-sdk:latest
 WORKDIR /ci
 COPY requirements.txt ./
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN pip3 install --no-cache-dir -r requirements.txt \
+RUN pip3 install --no-cache-dir --break-system-packages -r requirements.txt \
  && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
  && apt-get install --no-install-recommends -y nodejs \
  && npm i -g @dataform/cli@3.0.2


### PR DESCRIPTION
was hitting "error: externally-managed-environment" in building docker image in new project.

fixed run_unit_tests.sh screen/3fhhoy5tyQWgjAR