### PR TITLE
add UDF parse_timestamp

### DIFF
--- a/udfs/community/README.md
+++ b/udfs/community/README.md
@@ -155,7 +155,7 @@ SELECT bqutil.fn.int(1.684)
 * [nlp_compromise_number](#nlp_compromise_numberstr-string)
 * [nlp_compromise_people](#nlp_compromise_peoplestr-string)
 * [normal_cdf](#normal_cdfx-float64-mean-float64-stdev-float64)
-* [parse_timestamp_python](#parse_timestamp_python-f-string-s-string)
+* [parse_timestamp](#parse_timestamp-f-string-s-string)
 * [percentage_change](#percentage_changeval1-float64-val2-float64)
 * [percentage_difference](#percentage_differenceval1-float64-val2-float64)
 * [pi](#pi)
@@ -2313,11 +2313,11 @@ results:
 -----
 
 
-### [parse_timestamp_python(f STRING, s STRING)](parse_timestamp.sqlx)
+### [parse_timestamp(f STRING, s STRING)](parse_timestamp.sqlx)
 Parses a timestamp string according to a specified format string. Returns a TIMESTAMP value.
 
 ```sql
-SELECT bqutil.fn.parse_timestamp_python('%Y-%m-%d %H:%M:%S', '2024-03-20 14:30:00');
+SELECT bqutil.fn.parse_timestamp('%Y-%m-%d %H:%M:%S', '2024-03-20 14:30:00');
 
 2024-03-20 14:30:00 UTC
 ```

--- a/udfs/community/parse_timestamp.sqlx
+++ b/udfs/community/parse_timestamp.sqlx
@@ -15,10 +15,11 @@ config { hasOutput: true }
  * limitations under the License.
  */
 
+-- This UDF is added because BigQuery's parse_timestamp does not support the %F format code for fractional seconds, while this UDF does.
 -- Parses a string into a TIMESTAMP using the specified format string
 CREATE OR REPLACE FUNCTION ${self()}(f STRING, s STRING)
 RETURNS TIMESTAMP LANGUAGE python
-OPTIONS (entry_point='do_parse_timestamp', runtime_version='python-3.11', description='Parses a timestamp string according to a specified format string using Python\'s datetime.strptime(). Returns a TIMESTAMP value or NULL if parsing fails. Supports common format codes such as %Y, %m, %d, %H, %M, %S, and %F for fractional seconds.')
+OPTIONS (entry_point='do_parse_timestamp', runtime_version='python-3.11', description='Parses a timestamp string according to a specified format string. Returns a TIMESTAMP value or NULL if parsing fails. Supports common format codes such as %Y, %m, %d, %H, %M, %S, and %F for fractional seconds. BigQuery\'s parse_timestamp does not support %F.')
 AS r"""
 from datetime import datetime
 

--- a/udfs/community/test_cases.js
+++ b/udfs/community/test_cases.js
@@ -3764,7 +3764,7 @@ generate_udf_test("gunzip", [
   },
 ]);
 
-generate_udf_test("parse_timestamp_python", [
+generate_udf_test("parse_timestamp", [
   {
     inputs: [`'%Y-%m-%d %H:%M:%S'`, `'2024-03-20 14:30:00'`],
     expected_output: `TIMESTAMP '2024-03-20 14:30:00'`,


### PR DESCRIPTION
native parse_timestamp function parses fraction seconds as part of second using formt `E#S`. But other dialects like oracle sql could parse fraction second independently as `F`. So we need this UDF for that need in BQ translation. 

example:
parse_timestamp("21.234", "E3S")  can be parsed by BQ,  but parse_timestamp("21234", "SSE3F") can not be parsed by BQ