### PR TITLE
moment assumes PST instead of UTC. Change moment to create object assuming UTC to stay consistent with BQ. 

### DIFF
--- a/udfs/community/cw_parse_timestamp.sqlx
+++ b/udfs/community/cw_parse_timestamp.sqlx
@@ -23,7 +23,7 @@ CREATE OR REPLACE FUNCTION ${self()}(timeString STRING, formatString STRING)
     description="Emulates Oracle's TO_TIMESTAMP function.") AS
 """
 // Return timeString with the given formatString in BigQuery canonical ISO format
-const momentObject = moment(timeString, formatString);
+const momentObject = moment.utc(timeString, formatString);
 
 if(momentObject.isValid()) {
   return momentObject.toDate();

--- a/udfs/community/test_cases.js
+++ b/udfs/community/test_cases.js
@@ -3070,11 +3070,11 @@ generate_udf_test("bignumber_lte", [
 generate_udf_test("cw_parse_timestamp", [
   {
     inputs: [`"10-Sep-02 14:10:10.123000"`, `"DD-MMM-YY HH:mm:ss.SSSSSS"`,],
-    expected_output: `TIMESTAMP "2002-09-10 21:10:10.123000 UTC"`,
+    expected_output: `TIMESTAMP "2002-09-10 14:10:10.123000 UTC"`,
   },
   {
     inputs: [`"10-Sep-02 14:10:10123000"`, `"DD-MMM-YY HH:mm:ssSSSSSS"`,],
-    expected_output: `TIMESTAMP "2002-09-10 21:10:10.123000 UTC"`,
+    expected_output: `TIMESTAMP "2002-09-10 14:10:10.123000 UTC"`,
   },
   {
     inputs: [`"40-Sep-02 14:10:10123000"`, `"DD-MMM-YY HH:mm:ssSSSSSS"`,],


### PR DESCRIPTION
moment(...) is local mode. Ambiguous input (without offset) is assumed to be local time. Unambiguous input (with offset) is adjusted to local time.
moment.utc(...) is utc mode. Ambiguous input is assumed to be UTC. Unambiguous input is adjusted to UTC.
[[source for above]](https://momentjs.com/docs/#/parsing/)

This PR modifies bqutil.fn.cw_parse_timestamp to use moment.utc(...) to create timestamps assuming UTC to stay consistent with BQ. 

eg: 

```sql
SELECT
      parse_datetime('%Y%m%d %H%M%S', '20020211 123456') x,
      CAST(bqutil.fn.cw_parse_timestamp('20020211 123456789', 'YYYYMMDD HHmmssSSS') as DATETIME) z
```

outputs:
```
2002-02-11T12:34:56
2002-02-11T20:34:56.789000
```
They should be same with just difference in miliseconds.